### PR TITLE
Minify source code for prod build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.0.0",
   "description": "Website and 0x OTC dapp",
   "scripts": {
-    "build": "webpack",
+    "build:dev": "webpack",
+    "build:prod": "NODE_ENV=production webpack && uglifyjs public/bundle.js -c -m -o public/bundle.js",
     "dev": "webpack-dev-server --content-base public",
     "update_contracts": "copyfiles -u 4 ./../contracts/build/contracts/*.json ./contracts;",
-    "deploy_staging": "npm run build; aws s3 sync ./public/. s3://staging-0xproject --profile 0xproject --region us-east-1 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
-    "deploy_live": "npm run build; aws s3 sync ./public/. s3://0xproject.com --profile 0xproject --region us-east-1 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
+    "deploy_staging": "npm run build:prod; aws s3 sync ./public/. s3://staging-0xproject --profile 0xproject --region us-east-1 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
+    "deploy_live": "npm run build:prod; aws s3 sync ./public/. s3://0xproject.com --profile 0xproject --region us-east-1 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
     "testrpc": "testrpc -p 8545 --networkId 50"
   },
   "author": "Fabio Berger",
@@ -78,6 +79,7 @@
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",
     "webpack-dev-server": "^2.3.0",
+    "uglify-es": "^3.0.9",
     "ethereumjs-testrpc": "^3.0.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,15 @@
 const path = require('path');
 const webpack = require('webpack');
 
+const PRODUCTION = process.env.NODE_ENV === 'production';
+
 module.exports = {
     entry: ['./ts/index.tsx'],
     output: {
         path: path.join(__dirname, '/public'),
         filename: 'bundle.js',
     },
-    devtool: 'source-map',
+    devtool: PRODUCTION ? 'cheap-module-source-map' : 'source-map',
     resolve: {
         modules: [
             path.join(__dirname, '/ts'),
@@ -51,4 +53,13 @@ module.exports = {
       },
       disableHostCheck: true
     },
+    plugins: PRODUCTION ?
+        [
+            new webpack.DefinePlugin({
+                'process.env': {
+                    'NODE_ENV': JSON.stringify('production')
+                }
+            }),
+            new webpack.optimize.AggressiveMergingPlugin(),
+        ] : []
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     resolve: {
         modules: [
             path.join(__dirname, '/ts'),
-            'node_modules'
+            'node_modules',
         ],
         extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
         alias: {
@@ -38,28 +38,28 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                loaders: ['style-loader', 'css-loader']
+                loaders: ['style-loader', 'css-loader'],
             },
             {
                 test: /\.json$/,
-                loader: 'json-loader'
-            }
+                loader: 'json-loader',
+            },
         ],
     },
     devServer: {
         port: 8080,
         historyApiFallback: {
-          index: 'index.html'
+          index: 'index.html',
       },
-      disableHostCheck: true
+      disableHostCheck: true,
     },
     plugins: PRODUCTION ?
         [
             new webpack.DefinePlugin({
                 'process.env': {
-                    'NODE_ENV': JSON.stringify('production')
-                }
+                    'NODE_ENV': JSON.stringify('production'),
+                },
             }),
             new webpack.optimize.AggressiveMergingPlugin(),
-        ] : []
+        ] : [],
 };


### PR DESCRIPTION
# This PR:
* Runns uglifyjs after webpack build
* Reduces bundle size from `6.1` to `2.1` MB
* Resolves #47 

# Why don't I use webpack's `-p` flag?
`-p` uses uglifyjs under the hood and fails to minify `web3-provider-engine` which doesn't compile ES6 to ES5.
We use `uglify-es` instead.