### PR TITLE
Set allowance to 0 and set the default gas limit for approve transaction

### DIFF
--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -29,6 +29,7 @@ import * as BigNumber from 'bignumber.js';
 import ethUtil = require('ethereumjs-util');
 
 const MINT_AMOUNT = new BigNumber('100000000000000000000');
+const ALLOWANCE_TO_ZERO_GAS_AMOUNT = 45730;
 
 export class Blockchain {
     public networkId: number;
@@ -73,7 +74,7 @@ export class Blockchain {
         // Hack: for some reason default estimated gas amount causes `base fee exceeds gas limit` exception
         // on testrpc. Probably related to https://github.com/ethereumjs/testrpc/issues/294
         // TODO: Debug issue in testrpc and submit a PR, then remove this hack
-        const gas = this.networkId === constants.TESTRPC_NETWORK_ID ? 45730 : undefined;
+        const gas = this.networkId === constants.TESTRPC_NETWORK_ID ? ALLOWANCE_TO_ZERO_GAS_AMOUNT : undefined;
         await tokenContract.approve(this.proxy.address, amountInBaseUnits, {
             from: this.userAddress,
             gas,

--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -70,8 +70,13 @@ export class Blockchain {
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
         const tokenContract = await this.instantiateContractIfExistsAsync(TokenArtifacts, token.address);
+        // Hack: for some reason default estimated gas amount causes `base fee exceeds gas limit` exception
+        // on testrpc. Probably related to https://github.com/ethereumjs/testrpc/issues/294
+        // TODO: Debug issue in testrpc and submit a PR, then remove this hack
+        const gas = this.networkId === constants.TESTRPC_NETWORK_ID ? 45730 : undefined;
         await tokenContract.approve(this.proxy.address, amountInBaseUnits, {
             from: this.userAddress,
+            gas,
         });
         const allowance = amountInBaseUnits;
         this.dispatcher.replaceTokenAllowanceByAddress(token.address, allowance);

--- a/ts/components/inputs/allowance_toggle.tsx
+++ b/ts/components/inputs/allowance_toggle.tsx
@@ -68,11 +68,7 @@ export class AllowanceToggle extends React.Component<AllowanceToggleProps, Allow
             isSpinnerVisible: true,
         });
 
-        // Hack: for some reason setting allowance to 0 causes a `base fee exceeds gas limit` exception
-        // on testrpc. Any edits to this hack should include changes to the `isAllowanceSet` method below
-        // Setting it to 0 is not an issue on the Kovan testnet.
-        // TODO: Debug issue in testrpc and submit a PR, then remove this hack
-        let newAllowanceAmountInUnits = 1;
+        let newAllowanceAmountInUnits = 0;
         if (!this.isAllowanceSet()) {
             newAllowanceAmountInUnits = DEFAULT_ALLOWANCE_AMOUNT_IN_UNITS;
         }
@@ -97,6 +93,6 @@ export class AllowanceToggle extends React.Component<AllowanceToggleProps, Allow
     private isAllowanceSet() {
         const token = this.props.token;
         const allowanceInUnits = zeroEx.toUnitAmount(token.allowance, token.decimals);
-        return !allowanceInUnits.eq(0) && !allowanceInUnits.eq(1);
+        return !allowanceInUnits.eq(0);
     }
 }

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -22,6 +22,7 @@ export const constants = {
     TAKER_FEE: new BigNumber(0),
     TESTNET_NAME: 'Kovan',
     TESTNET_NETWORK_ID: 42,
+    TESTRPC_NETWORK_ID: 50,
     ETH_DECIMAL_PLACES: 18,
     iconUrlBySymbol: {
         REP: '/images/token_icons/augur.png',


### PR DESCRIPTION
This PR:
* Reduces the allowance hack
* Seta allowance to actual 0
* sets the default gas limit on TESTRPC