### PR TITLE
Switch to official BigNumber.js type def

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
+    "@types/bignumber.js": "^4.0.2",
     "@types/dateformat": "^1.0.1",
     "@types/deep-equal": "^1.0.0",
     "@types/es6-promise": "0.0.32",

--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -73,7 +73,7 @@ export class Blockchain {
             this.nodeVersion = nodeVersion;
         }
     }
-    public async setExchangeAllowanceAsync(token: Token, amountInBaseUnits: BigNumber) {
+    public async setExchangeAllowanceAsync(token: Token, amountInBaseUnits: BigNumber.BigNumber) {
         utils.assert(this.isValidAddress(token.address), BlockchainCallErrs.TOKEN_ADDRESS_IS_INVALID);
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
@@ -105,10 +105,11 @@ export class Blockchain {
         return isValidSignature;
     }
     public async fillOrderAsync(maker: string, taker: string, makerTokenAddress: string,
-                                takerTokenAddress: string, makerTokenAmount: BigNumber,
-                                takerTokenAmount: BigNumber, makerFee: BigNumber, takerFee: BigNumber,
-                                expirationUnixTimestampSec: BigNumber, feeRecipient: string,
-                                fillAmount: BigNumber, signatureData: SignatureData, salt: BigNumber) {
+                                takerTokenAddress: string, makerTokenAmount: BigNumber.BigNumber,
+                                takerTokenAmount: BigNumber.BigNumber, makerFee: BigNumber.BigNumber,
+                                takerFee: BigNumber.BigNumber, expirationUnixTimestampSec: BigNumber.BigNumber,
+                                feeRecipient: string, fillAmount: BigNumber.BigNumber,
+                                signatureData: SignatureData, salt: BigNumber.BigNumber) {
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
         taker = taker === '' ? constants.NULL_ADDRESS : taker;
@@ -147,7 +148,7 @@ export class Blockchain {
         }
         return response;
     }
-    public async getFillAmountAsync(orderHash: string): Promise<BigNumber> {
+    public async getFillAmountAsync(orderHash: string): Promise<BigNumber.BigNumber> {
         utils.assert(zeroEx.isValidOrderHash(orderHash), 'Must be valid orderHash');
         const fillAmount = await this.exchange.getUnavailableValueT.call(orderHash);
         return fillAmount;
@@ -223,7 +224,7 @@ export class Blockchain {
         const balanceDelta = constants.MINT_AMOUNT;
         this.dispatcher.updateTokenBalanceByAddress(token.address, balanceDelta);
     }
-    public async convertEthToWrappedEthTokensAsync(amount: BigNumber) {
+    public async convertEthToWrappedEthTokensAsync(amount: BigNumber.BigNumber) {
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
         const wethContract = await this.instantiateContractIfExistsAsync(EtherTokenArtifacts);
@@ -232,7 +233,7 @@ export class Blockchain {
             value: amount,
         });
     }
-    public async convertWrappedEthTokensToEthAsync(amount: BigNumber) {
+    public async convertWrappedEthTokensToEthAsync(amount: BigNumber.BigNumber) {
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
         const wethContract = await this.instantiateContractIfExistsAsync(EtherTokenArtifacts);
@@ -243,10 +244,11 @@ export class Blockchain {
     public async doesContractExistAtAddressAsync(address: string) {
         return await this.web3Wrapper.doesContractExistAtAddressAsync(address);
     }
-    public async getCurrentUserTokenBalanceAndAllowanceAsync(tokenAddress: string): Promise<BigNumber[]> {
+    public async getCurrentUserTokenBalanceAndAllowanceAsync(tokenAddress: string): Promise<BigNumber.BigNumber[]> {
       return await this.getTokenBalanceAndAllowanceAsync(this.userAddress, tokenAddress);
     }
-    public async getTokenBalanceAndAllowanceAsync(ownerAddress: string, tokenAddress: string): Promise<BigNumber[]> {
+    public async getTokenBalanceAndAllowanceAsync(ownerAddress: string, tokenAddress: string):
+                    Promise<BigNumber.BigNumber[]> {
         const tokenContract = await this.instantiateContractIfExistsAsync(TokenArtifacts, tokenAddress);
         let balance;
         let allowance;

--- a/ts/components/eth_weth_conversion_button.tsx
+++ b/ts/components/eth_weth_conversion_button.tsx
@@ -16,7 +16,7 @@ interface EthWethConversionButtonProps {
     ethToken: Token;
     dispatcher: Dispatcher;
     blockchain: Blockchain;
-    userEtherBalance: BigNumber;
+    userEtherBalance: BigNumber.BigNumber;
     onError: () => void;
 }
 
@@ -60,7 +60,7 @@ export class EthWethConversionButton extends
             isEthConversionDialogVisible: !this.state.isEthConversionDialogVisible,
         });
     }
-    private async onConversionAmountSelectedAsync(direction: Side, value: BigNumber) {
+    private async onConversionAmountSelectedAsync(direction: Side, value: BigNumber.BigNumber) {
         this.setState({
             isEthConversionHappening: true,
         });

--- a/ts/components/eth_weth_conversion_dialog.tsx
+++ b/ts/components/eth_weth_conversion_dialog.tsx
@@ -7,15 +7,15 @@ import {EthAmountInput} from 'ts/components/inputs/eth_amount_input';
 import * as BigNumber from 'bignumber.js';
 
 interface EthWethConversionDialogProps {
-    onComplete: (direction: Side, value: BigNumber) => void;
+    onComplete: (direction: Side, value: BigNumber.BigNumber) => void;
     onCancelled: () => void;
     isOpen: boolean;
     token: Token;
-    etherBalance: BigNumber;
+    etherBalance: BigNumber.BigNumber;
 }
 
 interface EthWethConversionDialogState {
-    value?: BigNumber;
+    value?: BigNumber.BigNumber;
     direction: Side;
     shouldShowIncompleteErrs: boolean;
     hasErrors: boolean;
@@ -103,7 +103,7 @@ export class EthWethConversionDialog extends
             hasErrors: true,
         });
     }
-    private onValueChange(isValid: boolean, amount?: BigNumber) {
+    private onValueChange(isValid: boolean, amount?: BigNumber.BigNumber) {
         this.setState({
             value: amount,
             hasErrors: !isValid,

--- a/ts/components/fill_order.tsx
+++ b/ts/components/fill_order.tsx
@@ -32,7 +32,7 @@ import * as moment from 'moment';
 interface FillOrderProps {
     blockchain: Blockchain;
     blockchainErr: BlockchainErrs;
-    orderFillAmount: BigNumber;
+    orderFillAmount: BigNumber.BigNumber;
     networkId: number;
     userAddress: string;
     tokenByAddress: TokenByAddress;
@@ -47,7 +47,7 @@ interface FillOrderState {
     orderJSONErrMsg: string;
     parsedOrder: Order;
     didFillOrderSucceed: boolean;
-    amountAlreadyFilled: BigNumber;
+    amountAlreadyFilled: BigNumber.BigNumber;
 }
 
 export class FillOrder extends React.Component<FillOrderProps, FillOrderState> {
@@ -217,7 +217,7 @@ export class FillOrder extends React.Component<FillOrderProps, FillOrderState> {
             </div>
         );
     }
-    private onFillAmountChange(isValid: boolean, amount?: BigNumber) {
+    private onFillAmountChange(isValid: boolean, amount?: BigNumber.BigNumber) {
         this.props.dispatcher.updateOrderFillAmount(amount);
     }
     private onFillOrderChanged(e: any) {

--- a/ts/components/generate_order/generate_order_form.tsx
+++ b/ts/components/generate_order/generate_order_form.tsx
@@ -43,12 +43,12 @@ interface GenerateOrderFormProps {
     blockchainIsLoaded: boolean;
     dispatcher: Dispatcher;
     hashData: HashData;
-    orderExpiryTimestamp: BigNumber;
+    orderExpiryTimestamp: BigNumber.BigNumber;
     networkId: number;
     userAddress: string;
     orderSignatureData: SignatureData;
     orderTakerAddress: string;
-    orderSalt: BigNumber;
+    orderSalt: BigNumber.BigNumber;
     sideToAssetToken: SideToAssetToken;
     tokenByAddress: TokenByAddress;
 }
@@ -221,7 +221,7 @@ export class GenerateOrderForm extends React.Component<GenerateOrderFormProps, a
             </div>
         );
     }
-    private onTokenAmountChange(token: Token, side: Side, isValid: boolean, amount?: BigNumber) {
+    private onTokenAmountChange(token: Token, side: Side, isValid: boolean, amount?: BigNumber.BigNumber) {
         this.props.dispatcher.updateChosenAssetToken(side, {address: token.address, amount});
     }
     private onCloseOrderJSONDialog() {

--- a/ts/components/inputs/allowance_toggle.tsx
+++ b/ts/components/inputs/allowance_toggle.tsx
@@ -21,7 +21,7 @@ interface AllowanceToggleProps {
 
 interface AllowanceToggleState {
     isSpinnerVisible: boolean;
-    prevAllowance: BigNumber;
+    prevAllowance: BigNumber.BigNumber;
 }
 
 export class AllowanceToggle extends React.Component<AllowanceToggleProps, AllowanceToggleState> {

--- a/ts/components/inputs/balance_bounded_input.tsx
+++ b/ts/components/inputs/balance_bounded_input.tsx
@@ -10,12 +10,12 @@ import {Link} from 'react-router-dom';
 
 interface BalanceBoundedInputProps {
     label: string;
-    balance: BigNumber;
-    amount?: BigNumber;
+    balance: BigNumber.BigNumber;
+    amount?: BigNumber.BigNumber;
     onChange: ValidatedBigNumberCallback;
     shouldShowIncompleteErrs?: boolean;
     shouldCheckBalance: boolean;
-    validate?: (amount: BigNumber) => InputErrMsg;
+    validate?: (amount: BigNumber.BigNumber) => InputErrMsg;
     onVisitBalancesPageClick?: () => void;
 }
 
@@ -104,7 +104,7 @@ export class BalanceBoundedInput extends
             }
         });
     }
-    private validate(amountString: string, balance: BigNumber): InputErrMsg {
+    private validate(amountString: string, balance: BigNumber.BigNumber): InputErrMsg {
         if (!utils.isNumeric(amountString)) {
             return amountString !== '' ? 'Must be a number' : '';
         }

--- a/ts/components/inputs/eth_amount_input.tsx
+++ b/ts/components/inputs/eth_amount_input.tsx
@@ -8,8 +8,8 @@ import {constants} from 'ts/utils/constants';
 
 interface EthAmountInputProps {
     label: string;
-    balance: BigNumber;
-    amount?: BigNumber;
+    balance: BigNumber.BigNumber;
+    amount?: BigNumber.BigNumber;
     onChange: ValidatedBigNumberCallback;
     shouldShowIncompleteErrs: boolean;
     onVisitBalancesPageClick?: () => void;
@@ -39,7 +39,7 @@ export class EthAmountInput extends React.Component<EthAmountInputProps, EthAmou
             </div>
         );
     }
-    private onChange(isValid: boolean, amount?: BigNumber) {
+    private onChange(isValid: boolean, amount?: BigNumber.BigNumber) {
         const baseUnitAmountIfExists = _.isUndefined(amount) ?
             undefined :
             zeroEx.toBaseUnitAmount(amount, constants.ETH_DECIMAL_PLACES);

--- a/ts/components/inputs/expiration_input.tsx
+++ b/ts/components/inputs/expiration_input.tsx
@@ -6,8 +6,8 @@ import * as BigNumber from 'bignumber.js';
 import * as moment from 'moment';
 
 interface ExpirationInputProps {
-    orderExpiryTimestamp: BigNumber;
-    updateOrderExpiry: (unixTimestampSec: BigNumber) => void;
+    orderExpiryTimestamp: BigNumber.BigNumber;
+    updateOrderExpiry: (unixTimestampSec: BigNumber.BigNumber) => void;
 }
 
 interface ExpirationInputState {

--- a/ts/components/inputs/token_amount_input.tsx
+++ b/ts/components/inputs/token_amount_input.tsx
@@ -10,7 +10,7 @@ import {Link} from 'react-router-dom';
 interface TokenAmountInputProps {
     label: string;
     token: Token;
-    amount?: BigNumber;
+    amount?: BigNumber.BigNumber;
     shouldShowIncompleteErrs: boolean;
     shouldCheckBalance: boolean;
     shouldCheckAllowance: boolean;
@@ -43,14 +43,14 @@ export class TokenAmountInput extends React.Component<TokenAmountInputProps, Tok
             </div>
         );
     }
-    private onChange(isValid: boolean, amount?: BigNumber) {
+    private onChange(isValid: boolean, amount?: BigNumber.BigNumber) {
         let baseUnitAmount;
         if (!_.isUndefined(amount)) {
             baseUnitAmount = zeroEx.toBaseUnitAmount(amount, this.props.token.decimals);
         }
         this.props.onChange(isValid, baseUnitAmount);
     }
-    private validate(amount: BigNumber): InputErrMsg {
+    private validate(amount: BigNumber.BigNumber): InputErrMsg {
         if (this.props.shouldCheckAllowance && amount.gt(this.props.token.allowance)) {
             return (
                 <span>

--- a/ts/components/order_json.tsx
+++ b/ts/components/order_json.tsx
@@ -12,13 +12,13 @@ import BigNumber = require('bignumber.js');
 
 interface OrderJSONProps {
     exchangeContractIfExists: string;
-    orderExpiryTimestamp: BigNumber;
+    orderExpiryTimestamp: BigNumber.BigNumber;
     orderSignatureData: SignatureData;
     orderTakerAddress: string;
     orderMakerAddress: string;
-    orderSalt: BigNumber;
-    orderMakerFee: BigNumber;
-    orderTakerFee: BigNumber;
+    orderSalt: BigNumber.BigNumber;
+    orderMakerFee: BigNumber.BigNumber;
+    orderTakerFee: BigNumber.BigNumber;
     orderFeeRecipient: string;
     networkId: number;
     sideToAssetToken: SideToAssetToken;

--- a/ts/components/otc.tsx
+++ b/ts/components/otc.tsx
@@ -43,10 +43,10 @@ export interface OTCAllProps {
     hashData: HashData;
     networkId: number;
     nodeVersion: string;
-    orderFillAmount: BigNumber;
+    orderFillAmount: BigNumber.BigNumber;
     screenWidth: ScreenWidths;
     tokenByAddress: TokenByAddress;
-    userEtherBalance: BigNumber;
+    userEtherBalance: BigNumber.BigNumber;
     userAddress: string;
     shouldBlockchainErrDialogBeOpen: boolean;
     userSuppliedOrderCache: Order;

--- a/ts/components/token_balances.tsx
+++ b/ts/components/token_balances.tsx
@@ -62,7 +62,7 @@ interface TokenBalancesProps {
     screenWidth: ScreenWidths;
     tokenByAddress: TokenByAddress;
     userAddress: string;
-    userEtherBalance: BigNumber;
+    userEtherBalance: BigNumber.BigNumber;
     networkId: number;
 }
 
@@ -278,7 +278,7 @@ export class TokenBalances extends React.Component<TokenBalancesProps, TokenBala
             errorType: BalanceErrs.wethConversionFailed,
         });
     }
-    private renderAmount(amount: BigNumber, decimals: number) {
+    private renderAmount(amount: BigNumber.BigNumber, decimals: number) {
       const unitAmount = zeroEx.toUnitAmount(amount, decimals);
       return unitAmount.toNumber().toFixed(PRECISION);
     }

--- a/ts/components/trade_history/trade_history_item.tsx
+++ b/ts/components/trade_history/trade_history_item.tsx
@@ -185,7 +185,7 @@ export class TradeHistoryItem extends React.Component<TradeHistoryItemProps, Tra
             </div>
         );
     }
-    private renderAmount(amount: BigNumber, symbol: string, decimals: number) {
+    private renderAmount(amount: BigNumber.BigNumber, symbol: string, decimals: number) {
         const unitAmount = zeroEx.toUnitAmount(amount, decimals);
         return (
             <span>

--- a/ts/containers/generate_order_form.tsx
+++ b/ts/containers/generate_order_form.tsx
@@ -24,11 +24,11 @@ interface GenerateOrderFormProps {
 interface ConnectedState {
     blockchainErr: BlockchainErrs;
     blockchainIsLoaded: boolean;
-    orderExpiryTimestamp: BigNumber;
+    orderExpiryTimestamp: BigNumber.BigNumber;
     orderSignatureData: SignatureData;
     userAddress: string;
     orderTakerAddress: string;
-    orderSalt: BigNumber;
+    orderSalt: BigNumber.BigNumber;
     networkId: number;
     sideToAssetToken: SideToAssetToken;
     tokenByAddress: TokenByAddress;

--- a/ts/globals.d.ts
+++ b/ts/globals.d.ts
@@ -23,40 +23,6 @@ declare module '*.json' {
     /* tslint:enable */
 }
 
-// Bignumber.js interface
-declare module 'bignumber.js' {
-
-    class BigNumber {
-        // Those static attributes could have been in the module, a few lines beneath
-        public static ROUND_DOWN: any;
-        public isBigNumber: boolean;
-        public static config(arg: any): void;
-        public static random(numDecimals: number): BigNumber;
-
-        constructor(value: number|string);
-        public toNumber(): number;
-        public toString(base?: number): string;
-        public toFixed(dp?: number, rm?: number): string;
-        public div(value: BigNumber): BigNumber;
-        public pow(exponent: BigNumber|number): BigNumber;
-        public times(value: BigNumber|number): BigNumber;
-        public plus(value: BigNumber|number): BigNumber;
-        public lt(value: BigNumber|number): BigNumber;
-        public lte(value: BigNumber|number): BigNumber;
-        public gte(value: BigNumber|number): BigNumber;
-        public gt(value: BigNumber|number): BigNumber;
-        public eq(value: BigNumber|number): BigNumber;
-        public minus(value: BigNumber): BigNumber;
-        public round(numDecimals?: BigNumber|number): BigNumber;
-    }
-
-    // A standalone class is not exportable, so there is an empty module
-    namespace BigNumber { }
-
-    // The exported values is the merge of the BigNumber class and the BigNumber module
-    export = BigNumber;
-}
-
 // Web3 interface
 // modules that you require must be in quotes, or they'll be considered as ambient global variables.
 declare module 'web3' {
@@ -89,14 +55,14 @@ declare module 'web3' {
 
             sign(address: string, message: string, callback: (err: Error, signData: string) => void): string;
 
-            getBlock(blockHash: string, callback: (err: Error, blockObj: any) => void): BigNumber;
+            getBlock(blockHash: string, callback: (err: Error, blockObj: any) => void): BigNumber.BigNumber;
 
             // https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethcontract
             contract(abi: IAbiDefinition[]): IContract;
 
             // https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgetbalance
             getBalance(addressHexString: string,
-                callback?: (err: any, result: BigNumber) => void): BigNumber;
+                callback?: (err: any, result: BigNumber.BigNumber) => void): BigNumber.BigNumber;
 
             // https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgetcode
             getCode(addressHexString: string,
@@ -115,7 +81,7 @@ declare module 'web3' {
 
         public currentProvider(): any;
 
-        public fromWei(amount: BigNumber, unit: string): BigNumber;
+        public fromWei(amount: BigNumber.BigNumber, unit: string): BigNumber.BigNumber;
 
         public isAddress(address: string): boolean;
     }

--- a/ts/redux/dispatcher.ts
+++ b/ts/redux/dispatcher.ts
@@ -47,7 +47,7 @@ export class Dispatcher {
             type: ActionTypes.UPDATE_GENERATE_ORDER_STEP,
         });
     }
-    public updateOrderSalt(salt: BigNumber) {
+    public updateOrderSalt(salt: BigNumber.BigNumber) {
         this.dispatch({
             data: salt,
             type: ActionTypes.UPDATE_ORDER_SALT,
@@ -95,7 +95,7 @@ export class Dispatcher {
             type: ActionTypes.UPDATE_USER_ADDRESS,
         });
     }
-    public updateOrderExpiry(unixTimestampSec: BigNumber) {
+    public updateOrderExpiry(unixTimestampSec: BigNumber.BigNumber) {
         this.dispatch({
             data: unixTimestampSec,
             type: ActionTypes.UPDATE_ORDER_EXPIRY,
@@ -130,7 +130,7 @@ export class Dispatcher {
             type: ActionTypes.UPDATE_TOKEN_BY_ADDRESS,
          });
     }
-    public replaceTokenAllowanceByAddress(address: string, allowance: BigNumber) {
+    public replaceTokenAllowanceByAddress(address: string, allowance: BigNumber.BigNumber) {
         this.dispatch({
             data: {
               address,
@@ -139,7 +139,7 @@ export class Dispatcher {
             type: ActionTypes.REPLACE_TOKEN_ALLOWANCE_BY_ADDRESS,
         });
     }
-    public updateTokenBalanceByAddress(address: string, balanceDelta: BigNumber) {
+    public updateTokenBalanceByAddress(address: string, balanceDelta: BigNumber.BigNumber) {
         this.dispatch({
             data: {
                 address,
@@ -154,7 +154,7 @@ export class Dispatcher {
             type: ActionTypes.UPDATE_ORDER_SIGNATURE_DATA,
          });
     }
-    public updateUserEtherBalance(balance: BigNumber) {
+    public updateUserEtherBalance(balance: BigNumber.BigNumber) {
         this.dispatch({
              data: balance,
             type: ActionTypes.UPDATE_USER_ETHER_BALANCE,
@@ -166,7 +166,7 @@ export class Dispatcher {
             type: ActionTypes.UPDATE_NETWORK_ID,
          });
     }
-    public updateOrderFillAmount(amount: BigNumber) {
+    public updateOrderFillAmount(amount: BigNumber.BigNumber) {
         this.dispatch({
             data: amount,
             type: ActionTypes.UPDATE_ORDER_FILL_AMOUNT,

--- a/ts/redux/reducer.ts
+++ b/ts/redux/reducer.ts
@@ -25,18 +25,18 @@ export interface State {
     blockchainIsLoaded: boolean;
     generateOrderStep: GenerateOrderSteps;
     networkId: number;
-    orderExpiryTimestamp: BigNumber;
-    orderFillAmount: BigNumber;
+    orderExpiryTimestamp: BigNumber.BigNumber;
+    orderFillAmount: BigNumber.BigNumber;
     orderTakerAddress: string;
     orderSignatureData: SignatureData;
-    orderSalt: BigNumber;
+    orderSalt: BigNumber.BigNumber;
     nodeVersion: string;
     screenWidth: ScreenWidths;
     shouldBlockchainErrDialogBeOpen: boolean;
     sideToAssetToken: SideToAssetToken;
     tokenByAddress: TokenByAddress;
     userAddress: string;
-    userEtherBalance: BigNumber;
+    userEtherBalance: BigNumber.BigNumber;
     // Note: cache of supplied orderJSON in fill order step. Do not use for anything else.
     userSuppliedOrderCache: Order;
     flashMessage: string;

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -42,8 +42,8 @@ export interface Token {
     name: string;
     address: string;
     symbol: string;
-    balance: BigNumber;
-    allowance: BigNumber;
+    balance: BigNumber.BigNumber;
+    allowance: BigNumber.BigNumber;
     decimals: number;
 };
 
@@ -53,7 +53,7 @@ export interface TokenByAddress {
 
 export interface AssetToken {
     address?: string;
-    amount?: BigNumber;
+    amount?: BigNumber.BigNumber;
 }
 
 export interface SideToAssetToken {
@@ -68,17 +68,17 @@ export interface SignatureData {
 };
 
 export interface HashData {
-    depositAmount: BigNumber;
+    depositAmount: BigNumber.BigNumber;
     depositTokenContractAddr: string;
     feeRecipientAddress: string;
-    makerFee: BigNumber;
-    orderExpiryTimestamp: BigNumber;
+    makerFee: BigNumber.BigNumber;
+    orderExpiryTimestamp: BigNumber.BigNumber;
     orderMakerAddress: string;
     orderTakerAddress: string;
-    receiveAmount: BigNumber;
+    receiveAmount: BigNumber.BigNumber;
     receiveTokenContractAddr: string;
-    takerFee: BigNumber;
-    orderSalt: BigNumber;
+    takerFee: BigNumber.BigNumber;
+    orderSalt: BigNumber.BigNumber;
 }
 
 export interface OrderToken {
@@ -112,10 +112,10 @@ export interface Fill {
     taker: string;
     tokenM: string;
     tokenT: string;
-    valueM: BigNumber;
-    valueT: BigNumber;
-    expiration: BigNumber;
-    filledValueT: BigNumber;
+    valueM: BigNumber.BigNumber;
+    valueT: BigNumber.BigNumber;
+    expiration: BigNumber.BigNumber;
+    filledValueT: BigNumber.BigNumber;
     orderHash: string;
     transactionHash: string;
     blockTimestamp: number;
@@ -234,7 +234,7 @@ export interface ContractEvent {
 }
 
 export type InputErrMsg = React.ReactNode | string | undefined;
-export type ValidatedBigNumberCallback = (isValid: boolean, amount?: BigNumber) => void;
+export type ValidatedBigNumberCallback = (isValid: boolean, amount?: BigNumber.BigNumber) => void;
 export const ScreenWidths = strEnum([
   'SM',
   'MD',

--- a/ts/utils/utils.ts
+++ b/ts/utils/utils.ts
@@ -34,11 +34,11 @@ export const utils = {
     // It is a fixed constant so that both the redux store's INITIAL_STATE and components can check for
     // whether a user has set an expiry date or not. It is set unrealistically high so as not to collide
     // with actual values a user would select.
-    initialOrderExpiryUnixTimestampSec(): BigNumber {
+    initialOrderExpiryUnixTimestampSec(): BigNumber.BigNumber {
         const m = moment('2050-01-01');
         return new BigNumber(m.unix());
     },
-    convertToUnixTimestampSeconds(date: moment.Moment, time?: moment.Moment): BigNumber {
+    convertToUnixTimestampSeconds(date: moment.Moment, time?: moment.Moment): BigNumber.BigNumber {
         const finalMoment = date;
         if (!_.isUndefined(time)) {
             finalMoment.hours(time.hours());
@@ -46,18 +46,18 @@ export const utils = {
         }
         return new BigNumber(finalMoment.unix());
     },
-    convertToMomentFromUnixTimestamp(unixTimestampSec: BigNumber): moment.Moment {
+    convertToMomentFromUnixTimestamp(unixTimestampSec: BigNumber.BigNumber): moment.Moment {
         return moment.unix(unixTimestampSec.toNumber());
     },
-    convertToReadableDateTimeFromUnixTimestamp(unixTimestampSec: BigNumber): string {
+    convertToReadableDateTimeFromUnixTimestamp(unixTimestampSec: BigNumber.BigNumber): string {
         const m = this.convertToMomentFromUnixTimestamp(unixTimestampSec);
         const formattedDate: string = m.format('h:MMa MMMM D YYYY');
         return formattedDate;
     },
     generateOrder(networkId: number, exchangeContract: string, sideToAssetToken: SideToAssetToken,
-                  orderExpiryTimestamp: BigNumber, orderTakerAddress: string, orderMakerAddress: string,
-                  makerFee: BigNumber, takerFee: BigNumber, feeRecipient: string, signatureData: SignatureData,
-                  tokenByAddress: TokenByAddress, orderSalt: BigNumber): Order {
+                  orderExpiryTimestamp: BigNumber.BigNumber, orderTakerAddress: string, orderMakerAddress: string,
+                  makerFee: BigNumber.BigNumber, takerFee: BigNumber.BigNumber, feeRecipient: string,
+                  signatureData: SignatureData, tokenByAddress: TokenByAddress, orderSalt: BigNumber.BigNumber): Order {
         const makerToken = tokenByAddress[sideToAssetToken[Side.deposit].address];
         const takerToken = tokenByAddress[sideToAssetToken[Side.receive].address];
         const order = {

--- a/ts/utils/zero_ex.ts
+++ b/ts/utils/zero_ex.ts
@@ -11,8 +11,9 @@ const MAX_DIGITS_IN_UNSIGNED_256_INT = 78;
 export const zeroEx = {
     getOrderHash(exchangeContractAddr: string, makerAddr: string, takerAddr: string,
                  depositTokenAddr: string, receiveTokenAddr: string, feeRecipient: string,
-                 depositAmt: BigNumber, receiveAmt: BigNumber, makerFee: BigNumber, takerFee: BigNumber,
-                 expiration: BigNumber, salt: BigNumber): string {
+                 depositAmt: BigNumber.BigNumber, receiveAmt: BigNumber.BigNumber,
+                 makerFee: BigNumber.BigNumber, takerFee: BigNumber.BigNumber,
+                 expiration: BigNumber.BigNumber, salt: BigNumber.BigNumber): string {
         takerAddr = takerAddr !== '' ? takerAddr : constants.NULL_ADDRESS;
         const orderParts = [
             exchangeContractAddr,
@@ -46,7 +47,7 @@ export const zeroEx = {
             const isNumber = _.isFinite(arg);
             if (isNumber) {
                 argTypes.push(SolidityTypes.uint8);
-            } else if (_.isObject(arg) && (arg as BigNumber).isBigNumber) {
+            } else if (_.isObject(arg) && (arg as BigNumber.BigNumber).isBigNumber) {
                 argTypes.push(SolidityTypes.uint256);
                 args[i] = new BN(arg.toString(), 10);
             } else if (ethUtil.isValidAddress(arg)) {
@@ -65,7 +66,7 @@ export const zeroEx = {
     // A unit amount is defined as the amount of a currency just above the decimal places.
     // E.g: If a currency has 18 decimal places, 1e18 or one quintillion of the currency is equivalent
     // to 1 unit.
-    toUnitAmount(amount: BigNumber, decimals: number): BigNumber {
+    toUnitAmount(amount: BigNumber.BigNumber, decimals: number): BigNumber.BigNumber {
       const aUnit = new BigNumber(10).pow(decimals);
       const unit = amount.div(aUnit);
       return unit;
@@ -73,7 +74,7 @@ export const zeroEx = {
     // A baseUnit is defined as the smallest denomination of a currency. An amount expressed in baseUnits
     // is the amount expressed in the smallest denomination.
     // E.g: 1 unit of a currency with 18 decimal places is expressed in baseUnits as 1000000000000000000
-    toBaseUnitAmount(amount: BigNumber, decimals: number): BigNumber {
+    toBaseUnitAmount(amount: BigNumber.BigNumber, decimals: number): BigNumber.BigNumber {
       const unit = new BigNumber(10).pow(decimals);
       const baseUnitAmount = amount.times(unit);
       return baseUnitAmount;
@@ -97,7 +98,7 @@ export const zeroEx = {
             return false;
         }
     },
-    generateSalt(): BigNumber {
+    generateSalt(): BigNumber.BigNumber {
         // BigNumber.random returns a random number between 0 & 1 with a passed in number of decimal
         // places. Source: https://mikemcl.github.io/bignumber.js/#random
         const randomNumber = BigNumber.random(MAX_DIGITS_IN_UNSIGNED_256_INT);

--- a/ts/web3_wrapper.ts
+++ b/ts/web3_wrapper.ts
@@ -77,7 +77,7 @@ export class Web3Wrapper {
             return undefined;
         }
     }
-    public async getBalanceInEthAsync(owner: string): Promise<BigNumber> {
+    public async getBalanceInEthAsync(owner: string): Promise<BigNumber.BigNumber> {
         const balanceInWei = await promisify(this.web3.eth.getBalance)(owner);
         const balanceEth = this.web3.fromWei(balanceInWei, 'ether');
         return balanceEth;


### PR DESCRIPTION
This PR:

- Switches us over from our custom BigNumber.js type definition to the official DefinitelyTyped version. The type must now be referenced as `BigNumber.BigNumber`.