### PR TITLE
Update OTC to handle new fill event schema

### DIFF
--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -323,24 +323,23 @@ export class Blockchain {
                     tradeHistoryStorage.setFillsLatestBlock(this.userAddress, this.networkId, blockNumberToSet);
                 }
                 const isUserMakerOrTaker = args.maker === this.userAddress ||
-                                           args.taker === this.userAddress ||
-                                           args.filledBy === this.userAddress;
+                                           args.taker === this.userAddress;
                 if (!isUserMakerOrTaker) {
                     return; // We aren't interested in the fill event
                 }
                 const blockTimestamp = await this.web3Wrapper.getBlockTimestampAsync(result.blockHash);
                 const fill = {
-                    expiration: args.expiration.toNumber(),
                     filledValueT: args.filledValueT,
+                    filledValueM: args.filledValueM,
                     logIndex: result.logIndex,
                     maker: args.maker,
                     orderHash: args.orderHash,
-                    taker: args.filledBy,
+                    taker: args.taker,
                     tokenM: args.tokenM,
                     tokenT: args.tokenT,
+                    feeMPaid: args.feeMPaid,
+                    feeTPaid: args.feeTPaid,
                     transactionHash: result.transactionHash,
-                    valueM: args.valueM,
-                    valueT: args.valueT,
                     blockTimestamp,
                 };
                 tradeHistoryStorage.addFillToUser(this.userAddress, this.networkId, fill);

--- a/ts/components/trade_history/trade_history_item.tsx
+++ b/ts/components/trade_history/trade_history_item.tsx
@@ -113,12 +113,10 @@ export class TradeHistoryItem extends React.Component<TradeHistoryItemProps, Tra
     }
     private renderAmounts(tokenM: Token, tokenT: Token) {
         const fill = this.props.fill;
-        const valueTInUnits = zeroEx.toUnitAmount(fill.valueT, tokenT.decimals);
-        const valueMInUnits = zeroEx.toUnitAmount(fill.valueM, tokenM.decimals);
-        let exchangeRate = valueTInUnits.div(valueMInUnits);
         const filledValueTInUnits = zeroEx.toUnitAmount(fill.filledValueT, tokenT.decimals);
-        const fillValueMInUnits = filledValueTInUnits.div(exchangeRate);
-        const fillValueM = zeroEx.toBaseUnitAmount(fillValueMInUnits, tokenM.decimals);
+        const filledValueMInUnits = zeroEx.toUnitAmount(fill.filledValueM, tokenT.decimals);
+        let exchangeRate = filledValueTInUnits.div(filledValueMInUnits);
+        const fillValueM = zeroEx.toBaseUnitAmount(filledValueMInUnits, tokenM.decimals);
 
         let receiveAmount;
         let receiveToken;

--- a/ts/index.tsx
+++ b/ts/index.tsx
@@ -11,6 +11,7 @@ import {OTC} from 'ts/containers/otc';
 import {State, reducer} from 'ts/redux/reducer';
 import {colors, getMuiTheme, MuiThemeProvider} from 'material-ui/styles';
 import {Switch, BrowserRouter as Router, Route, Link} from 'react-router-dom';
+import {tradeHistoryStorage} from 'ts/local_storage/trade_history_storage';
 import * as injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
 
@@ -19,6 +20,9 @@ injectTapEventPlugin();
 BigNumber.config({
     EXPONENTIAL_AT: 1000,
 });
+
+// Check if we need to force clear the tradeHistory local storage entries
+tradeHistoryStorage.forceClearIfRequired();
 
 const CUSTOM_GREY = 'rgb(39, 39, 39)';
 const CUSTOM_GREEN = 'rgb(102, 222, 117)';

--- a/ts/index.tsx
+++ b/ts/index.tsx
@@ -21,8 +21,8 @@ BigNumber.config({
     EXPONENTIAL_AT: 1000,
 });
 
-// Check if we need to force clear the tradeHistory local storage entries
-tradeHistoryStorage.forceClearIfRequired();
+// Check if we've introduced an update that requires us to clear the tradeHistory local storage entries
+tradeHistoryStorage.clearIfRequired();
 
 const CUSTOM_GREY = 'rgb(39, 39, 39)';
 const CUSTOM_GREEN = 'rgb(102, 222, 117)';

--- a/ts/local_storage/local_storage.ts
+++ b/ts/local_storage/local_storage.ts
@@ -26,4 +26,10 @@ export const localStorage = {
         }
         window.localStorage.removeItem(key);
     },
+    getAllKeys(): string[] {
+        if (!this.doesExist) {
+            return [];
+        }
+        return _.keys(window.localStorage);
+    },
 };

--- a/ts/local_storage/trade_history_storage.tsx
+++ b/ts/local_storage/trade_history_storage.tsx
@@ -29,9 +29,10 @@ export const tradeHistoryStorage = {
         }
         const userFillsByHash = JSON.parse(userFillsJSONString);
         _.each(userFillsByHash, (fill, hash) => {
-          fill.valueT = new BigNumber(fill.valueT);
-          fill.valueM = new BigNumber(fill.valueM);
+          fill.feeMPaid = new BigNumber(fill.feeMPaid);
+          fill.feeTPaid = new BigNumber(fill.feeTPaid);
           fill.filledValueT = new BigNumber(fill.filledValueT);
+          fill.filledValueM = new BigNumber(fill.filledValueM);
         });
         return userFillsByHash;
     },

--- a/ts/local_storage/trade_history_storage.tsx
+++ b/ts/local_storage/trade_history_storage.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import {Fill} from 'ts/types';
+import {configs} from 'ts/utils/configs';
 import {localStorage} from 'ts/local_storage/local_storage';
 import ethUtil = require('ethereumjs-util');
 import * as BigNumber from 'bignumber.js';
@@ -7,8 +8,23 @@ import * as BigNumber from 'bignumber.js';
 const FILLS_KEY = 'fills';
 const FILLS_LATEST_BLOCK = 'fillsLatestBlock';
 const GENESIS_BLOCK_NUMBER = 0;
+const FORCE_CLEAR_KEY = 'lastForceClearDate';
 
 export const tradeHistoryStorage = {
+    // Force clear all fill related localstorage if we've updated the config variable in an update
+    // that introduces changes where we need the user to re-fetch the fills from the blockchain
+    forceClearIfRequired() {
+        const lastForceClearDate = localStorage.getItemIfExists(FORCE_CLEAR_KEY);
+        if (lastForceClearDate !== configs.lastForcedLocalStorageFillClearanceDate) {
+            const localStorageKeys = localStorage.getAllKeys();
+            _.each(localStorageKeys, key => {
+                if (_.startsWith(key, 'fills-') || _.startsWith(key, 'fillsLatestBlock-')) {
+                    localStorage.removeItem(key);
+                }
+            });
+        }
+        localStorage.setItem(FORCE_CLEAR_KEY, configs.lastForcedLocalStorageFillClearanceDate);
+    },
     addFillToUser(userAddress: string, networkId: number, fill: Fill) {
         const fillsByHash = this.getUserFillsByHash(userAddress, networkId);
         const fillHash = this._getFillHash(fill);

--- a/ts/local_storage/trade_history_storage.tsx
+++ b/ts/local_storage/trade_history_storage.tsx
@@ -8,15 +8,15 @@ import * as BigNumber from 'bignumber.js';
 const FILLS_KEY = 'fills';
 const FILLS_LATEST_BLOCK = 'fillsLatestBlock';
 const GENESIS_BLOCK_NUMBER = 0;
-const FORCE_CLEAR_KEY = 'lastForceClearDate';
+const FILL_CLEAR_KEY = 'lastClearFillDate';
 
 export const tradeHistoryStorage = {
-    // Force clear all fill related localStorage if we've updated the config variable in an update
+    // Clear all fill related localStorage if we've updated the config variable in an update
     // that introduced a backward incompatible change requiring the user to re-fetch the fills from
     // the blockchain
-    forceClearIfRequired() {
-        const lastForceClearDate = localStorage.getItemIfExists(FORCE_CLEAR_KEY);
-        if (lastForceClearDate !== configs.lastForcedLocalStorageFillClearanceDate) {
+    clearIfRequired() {
+        const lastClearFillDate = localStorage.getItemIfExists(FILL_CLEAR_KEY);
+        if (lastClearFillDate !== configs.lastLocalStorageFillClearanceDate) {
             const localStorageKeys = localStorage.getAllKeys();
             _.each(localStorageKeys, key => {
                 if (_.startsWith(key, `${FILLS_KEY}-`) || _.startsWith(key, `${FILLS_LATEST_BLOCK}-`)) {
@@ -24,7 +24,7 @@ export const tradeHistoryStorage = {
                 }
             });
         }
-        localStorage.setItem(FORCE_CLEAR_KEY, configs.lastForcedLocalStorageFillClearanceDate);
+        localStorage.setItem(FILL_CLEAR_KEY, configs.lastLocalStorageFillClearanceDate);
     },
     addFillToUser(userAddress: string, networkId: number, fill: Fill) {
         const fillsByHash = this.getUserFillsByHash(userAddress, networkId);

--- a/ts/local_storage/trade_history_storage.tsx
+++ b/ts/local_storage/trade_history_storage.tsx
@@ -19,7 +19,7 @@ export const tradeHistoryStorage = {
         if (lastForceClearDate !== configs.lastForcedLocalStorageFillClearanceDate) {
             const localStorageKeys = localStorage.getAllKeys();
             _.each(localStorageKeys, key => {
-                if (_.startsWith(key, 'fills-') || _.startsWith(key, 'fillsLatestBlock-')) {
+                if (_.startsWith(key, `${FILLS_KEY}-`) || _.startsWith(key, `${FILLS_LATEST_BLOCK}-`)) {
                     localStorage.removeItem(key);
                 }
             });

--- a/ts/local_storage/trade_history_storage.tsx
+++ b/ts/local_storage/trade_history_storage.tsx
@@ -11,8 +11,9 @@ const GENESIS_BLOCK_NUMBER = 0;
 const FORCE_CLEAR_KEY = 'lastForceClearDate';
 
 export const tradeHistoryStorage = {
-    // Force clear all fill related localstorage if we've updated the config variable in an update
-    // that introduces changes where we need the user to re-fetch the fills from the blockchain
+    // Force clear all fill related localStorage if we've updated the config variable in an update
+    // that introduced a backward incompatible change requiring the user to re-fetch the fills from
+    // the blockchain
     forceClearIfRequired() {
         const lastForceClearDate = localStorage.getItemIfExists(FORCE_CLEAR_KEY);
         if (lastForceClearDate !== configs.lastForcedLocalStorageFillClearanceDate) {

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -112,10 +112,10 @@ export interface Fill {
     taker: string;
     tokenM: string;
     tokenT: string;
-    valueM: BigNumber.BigNumber;
-    valueT: BigNumber.BigNumber;
-    expiration: BigNumber.BigNumber;
+    filledValueM: BigNumber.BigNumber;
     filledValueT: BigNumber.BigNumber;
+    feeMPaid: BigNumber.BigNumber;
+    feeTPaid: BigNumber.BigNumber;
     orderHash: string;
     transactionHash: string;
     blockTimestamp: number;

--- a/ts/utils/configs.ts
+++ b/ts/utils/configs.ts
@@ -12,5 +12,5 @@ export const configs = {
     ENVIRONMENT: isDevelopment ? Environments.DEVELOPMENT : Environments.PRODUCTION,
     symbolsOfMintableTokens: ['MKR', 'MLN', 'GNT', 'DGD', 'REP', 'ZRX'],
     mostPopularTradingPairSymbols: ['WETH', 'GNT'],
-    lastForcedLocalStorageFillClearanceDate: '2017-05-30',
+    lastLocalStorageFillClearanceDate: '2017-05-30',
 };

--- a/ts/utils/configs.ts
+++ b/ts/utils/configs.ts
@@ -12,4 +12,5 @@ export const configs = {
     ENVIRONMENT: isDevelopment ? Environments.DEVELOPMENT : Environments.PRODUCTION,
     symbolsOfMintableTokens: ['MKR', 'MLN', 'GNT', 'DGD', 'REP', 'ZRX'],
     mostPopularTradingPairSymbols: ['WETH', 'GNT'],
+    lastForcedLocalStorageFillClearanceDate: '2017-05-30',
 };


### PR DESCRIPTION
This PR:
- Updates the Fill type to the updated schema
- Adjusts any logic relying on the old Fill type schema
- Forces clients to clear fillEvents stored in their local storage that are of the outdated format.