### PR TITLE
Set unlimited allowance in OTC

### DIFF
--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -157,12 +157,15 @@ export class Blockchain {
         // Hack: for some reason default estimated gas amount causes `base fee exceeds gas limit` exception
         // on testrpc. Probably related to https://github.com/ethereumjs/testrpc/issues/294
         // TODO: Debug issue in testrpc and submit a PR, then remove this hack
-        const estimatedGas = await tokenContract.approve.estimateGas(this.tokenTransferProxy.address,
-                                                                      amountInBaseUnits, {
-                                                                        from: this.userAddress,
-                                                                        gas: ALLOWANCE_TO_ZERO_GAS_AMOUNT,
-        });
-        const gas = this.networkId === constants.TESTRPC_NETWORK_ID ? ALLOWANCE_TO_ZERO_GAS_AMOUNT : estimatedGas;
+        const estimatedGas = await tokenContract.approve.estimateGas(
+            this.tokenTransferProxy.address, amountInBaseUnits,
+            {
+                from: this.userAddress,
+            },
+        );
+        const gas = this.networkId === constants.TESTRPC_NETWORK_ID && amountInBaseUnits.eq(0) ?
+                    ALLOWANCE_TO_ZERO_GAS_AMOUNT :
+                    estimatedGas;
         await tokenContract.approve(this.tokenTransferProxy.address, amountInBaseUnits, {
             from: this.userAddress,
             gas,

--- a/ts/components/inputs/allowance_toggle.tsx
+++ b/ts/components/inputs/allowance_toggle.tsx
@@ -9,7 +9,7 @@ import {Token, BalanceErrs} from 'ts/types';
 import {utils} from 'ts/utils/utils';
 import {errorReporter} from 'ts/utils/error_reporter';
 
-const DEFAULT_ALLOWANCE_AMOUNT_IN_UNITS = 1000000000;
+const DEFAULT_ALLOWANCE_AMOUNT_IN_BASE_UNITS = new BigNumber(2).pow(256).minus(1);
 
 interface AllowanceToggleProps {
     blockchain: Blockchain;
@@ -68,14 +68,12 @@ export class AllowanceToggle extends React.Component<AllowanceToggleProps, Allow
             isSpinnerVisible: true,
         });
 
-        let newAllowanceAmountInUnits = 0;
+        let newAllowanceAmountInBaseUnits = new BigNumber(0);
         if (!this.isAllowanceSet()) {
-            newAllowanceAmountInUnits = DEFAULT_ALLOWANCE_AMOUNT_IN_UNITS;
+            newAllowanceAmountInBaseUnits = DEFAULT_ALLOWANCE_AMOUNT_IN_BASE_UNITS;
         }
         try {
-            const allowanceInUnits = new BigNumber(newAllowanceAmountInUnits);
-            const amountInBaseUnits = ZeroEx.toBaseUnitAmount(allowanceInUnits, this.props.token.decimals);
-            await this.props.blockchain.setProxyAllowanceAsync(this.props.token, amountInBaseUnits);
+            await this.props.blockchain.setProxyAllowanceAsync(this.props.token, newAllowanceAmountInBaseUnits);
         } catch (err) {
             this.setState({
                 isSpinnerVisible: false,
@@ -92,7 +90,6 @@ export class AllowanceToggle extends React.Component<AllowanceToggleProps, Allow
     }
     private isAllowanceSet() {
         const token = this.props.token;
-        const allowanceInUnits = ZeroEx.toUnitAmount(token.allowance, token.decimals);
-        return !allowanceInUnits.eq(0);
+        return !token.allowance.eq(0);
     }
 }


### PR DESCRIPTION
This PR:
* Makes OTC default allowance 2**256 - 1, which reduces the gas consumption by trades that include tokens that support unlimited allowance.