### PR TITLE
Make ZRX token first in token balances list

### DIFF
--- a/ts/components/token_balances.tsx
+++ b/ts/components/token_balances.tsx
@@ -42,6 +42,7 @@ import {EthWethConversionButton} from 'ts/components/eth_weth_conversion_button'
 
 const ETHER_ICON_PATH = '/images/ether.png';
 const ETHER_TOKEN_SYMBOL = 'WETH';
+const ZRX_TOKEN_SYMBOL = 'ZRX';
 
 const PRECISION = 5;
 const ICON_DIMENSION = 40;
@@ -297,6 +298,7 @@ export class TokenBalances extends React.Component<TokenBalancesProps, TokenBala
         const tokens = _.values(this.props.tokenByAddress);
         const tokensStartingWithEtherToken = tokens.sort(
             firstBy((t: Token) => (t.symbol !== ETHER_TOKEN_SYMBOL))
+            .thenBy((t: Token) => (t.symbol !== ZRX_TOKEN_SYMBOL))
             .thenBy('address'),
         );
         const tableRows = _.map(


### PR DESCRIPTION
This PR:
* Makes sure, that ZRX token is always first after the WETH token in OTC token balances
<img width="752" alt="screen shot 2017-08-21 at 17 57 35" src="https://user-images.githubusercontent.com/6204356/29527828-4d6fb3da-869a-11e7-838e-4c20d05b7808.png">
