### PR TITLE
Fix Fake Token Exploit

### DIFF
--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -82,6 +82,16 @@ export class Blockchain {
             this.nodeVersion = nodeVersion;
         }
     }
+    public async isAddressInTokenRegistryAsync(tokenAddress: string): Promise<boolean> {
+        utils.assert(!_.isUndefined(this.tokenRegistry), 'TokenRegistry must be instantiated');
+        const tokenMetadata = await this.tokenRegistry.getTokenMetaData.call(tokenAddress);
+        return tokenMetadata[0] !== constants.NULL_ADDRESS;
+    }
+    public async isSymbolInTokenRegistryAsync(symbol: string): Promise<boolean> {
+        utils.assert(!_.isUndefined(this.tokenRegistry), 'TokenRegistry must be instantiated');
+        const tokenMetadata = await this.tokenRegistry.getTokenBySymbol.call(symbol);
+        return tokenMetadata[0] !== constants.NULL_ADDRESS;
+    }
     public getLedgerDerivationPathIfExists(): string {
         if (_.isUndefined(this.ledgerSubProvider)) {
             return undefined;


### PR DESCRIPTION
This PR:
- Does not allow OTC to render orders that involve custom tokens with the same symbol as a token in the 0x tokenRegistry unless it also has the same contract address.