### PR TITLE
Use 0x.js for fetching addresses and filling orders

### DIFF
--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -186,21 +186,6 @@ export class Blockchain {
         const allowance = amountInBaseUnits;
         this.dispatcher.replaceTokenAllowanceByAddress(token.address, allowance);
     }
-    public async isValidSignatureAsync(maker: string, signatureData: SignatureData) {
-        utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
-
-        const isValidSignature = await this.exchange.isValidSignature.call(
-            maker,
-            signatureData.hash,
-            signatureData.v,
-            signatureData.r,
-            signatureData.s,
-            {
-                from: this.userAddress,
-            },
-        );
-        return isValidSignature;
-    }
     public async fillOrderAsync(maker: string, taker: string, makerTokenAddress: string,
                                 takerTokenAddress: string, makerTokenAmount: BigNumber.BigNumber,
                                 takerTokenAmount: BigNumber.BigNumber, makerFee: BigNumber.BigNumber,

--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -214,12 +214,9 @@ export class Blockchain {
         };
         const shouldThrowOnInsufficientBalanceOrAllowance = true;
 
-        console.log('signedOrder', signedOrder);
-        console.log('this.userAddress', this.userAddress);
         const amountFilledInTakerTokens = await this.zeroEx.exchange.fillOrderAsync(
             signedOrder, fillTakerTokenAmount, shouldThrowOnInsufficientBalanceOrAllowance, this.userAddress,
         );
-        console.log('got here');
         return amountFilledInTakerTokens;
     }
     public async getFillAmountAsync(orderHash: string): Promise<BigNumber.BigNumber> {

--- a/ts/blockchain.ts
+++ b/ts/blockchain.ts
@@ -219,11 +219,10 @@ export class Blockchain {
         );
         return amountFilledInTakerTokens;
     }
-    public async getFillAmountAsync(orderHash: string): Promise<BigNumber.BigNumber> {
+    public async getUnavailableTakerAmountAsync(orderHash: string): Promise<BigNumber.BigNumber> {
         utils.assert(ZeroEx.isValidOrderHash(orderHash), 'Must be valid orderHash');
-        const fillAmountOldBigNumber = await this.exchange.getUnavailableTakerTokenAmount.call(orderHash);
-        const fillAmount = new BigNumber(fillAmountOldBigNumber);
-        return fillAmount;
+        const unavailableTakerAmount = await this.zeroEx.exchange.getUnavailableTakerAmountAsync(orderHash);
+        return unavailableTakerAmount;
     }
     public getExchangeContractAddressIfExists() {
         return this.exchange ? this.exchange.address : undefined;

--- a/ts/components/fill_order.tsx
+++ b/ts/components/fill_order.tsx
@@ -358,13 +358,8 @@ export class FillOrder extends React.Component<FillOrderProps, FillOrderState> {
         const takerAddress = this.props.userAddress;
         const takerToken = this.props.tokenByAddress[takerTokenAddress];
         let isValidSignature = false;
-        if (this.props.userAddress === '') {
-            const signatureData = parsedOrder.signature;
-            isValidSignature = ZeroEx.isValidSignature(signatureData.hash, signatureData, parsedOrder.maker.address);
-        } else {
-            isValidSignature = await this.props.blockchain.isValidSignatureAsync(parsedOrder.maker.address,
-                                                              parsedOrder.signature);
-        }
+        const signatureData = parsedOrder.signature;
+        isValidSignature = ZeroEx.isValidSignature(signatureData.hash, signatureData, parsedOrder.maker.address);
 
         if (_.isUndefined(takerAddress)) {
             this.props.dispatcher.updateShouldBlockchainErrDialogBeOpen(true);

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -225,13 +225,18 @@ export const SolidityTypes = strEnum([
 export type SolidityTypes = keyof typeof SolidityTypes;
 
 export enum ExchangeContractErrs {
-  ERROR_FILL_EXPIRED, // Order has already expired
-  ERROR_FILL_NO_VALUE, // Order has already been fully filled or cancelled
-  ERROR_FILL_TRUNCATION, // Rounding error too large
-  ERROR_FILL_BALANCE_ALLOWANCE, // Insufficient balance or allowance for token transfer
-  ERROR_CANCEL_EXPIRED, // Order has already expired
-  ERROR_CANCEL_NO_VALUE, // Order has already been fully filled or cancelled
-};
+    OrderFillExpired = 'ORDER_FILL_EXPIRED',
+    OrderAlreadyCancelledOrFilled = 'ORDER_ALREADY_CANCELLED_OR_FILLED',
+    OrderRemainingFillAmountZero = 'ORDER_REMAINING_FILL_AMOUNT_ZERO',
+    OrderFillRoundingError = 'ORDER_FILL_ROUNDING_ERROR',
+    FillBalanceAllowanceError = 'FILL_BALANCE_ALLOWANCE_ERROR',
+    InsufficientTakerBalance = 'INSUFFICIENT_TAKER_BALANCE',
+    InsufficientTakerAllowance = 'INSUFFICIENT_TAKER_ALLOWANCE',
+    InsufficientMakerBalance = 'INSUFFICIENT_MAKER_BALANCE',
+    InsufficientMakerAllowance = 'INSUFFICIENT_MAKER_ALLOWANCE',
+    TransactionSenderIsNotFillOrderTaker = 'TRANSACTION_SENDER_IS_NOT_FILL_ORDER_TAKER',
+    InsufficientRemainingFillAmount = 'INSUFFICIENT_REMAINING_FILL_AMOUNT',
+}
 
 export interface ContractResponse {
     logs: ContractEvent[];

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -88,14 +88,6 @@ export const constants = {
         'LUN': '/images/token_icons/lunyr.png',
         'RLC': '/images/token_icons/iexec.png',
     } as {[symbol: string]: string},
-    exchangeContractErrToMsg: {
-        [ExchangeContractErrs.ERROR_FILL_EXPIRED]: 'The order you attempted to fill is expired',
-        [ExchangeContractErrs.ERROR_CANCEL_EXPIRED]: 'The order you attempted to cancel is expired',
-        [ExchangeContractErrs.ERROR_FILL_NO_VALUE]: 'This order has already been filled or cancelled',
-        [ExchangeContractErrs.ERROR_CANCEL_NO_VALUE]: 'This order has already been filled or cancelled',
-        [ExchangeContractErrs.ERROR_FILL_TRUNCATION]: 'The rounding error was too large when filling this order',
-        [ExchangeContractErrs.ERROR_FILL_BALANCE_ALLOWANCE]: 'Maker or taker has insufficient balance or allowance',
-    },
     networkNameById: {
         1: 'Frontier',
         3: 'Ropsten',


### PR DESCRIPTION
This PR:
- uses zeroEx.getAvailableAddressesAsync and zeroEx.exchange.fillOrderAsync in OTC
- removes isValidSignature that calls the exchange contract and always use the 0x.js version