### PR TITLE
Hot fix: Add allowance confirmation for custom tokens

### DIFF
--- a/ts/components/allowance_confirmation_dialog.tsx
+++ b/ts/components/allowance_confirmation_dialog.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import {colors} from 'material-ui/styles';
+import FlatButton from 'material-ui/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton';
+import Dialog from 'material-ui/Dialog';
+import {constants} from 'ts/utils/constants';
+import {utils} from 'ts/utils/utils';
+import {Token, EtherscanLinkSuffixes} from 'ts/types';
+import {CopyIcon} from 'ts/components/ui/copy_icon';
+
+interface AllowanceConfirmationDialogProps {
+    isOpen: boolean;
+    onToggleDialog: (isConfirmed: boolean) => void;
+    token: Token;
+    networkId: number;
+}
+
+export function AllowanceConfirmationDialog(props: AllowanceConfirmationDialogProps) {
+    const isConfirmed = true;
+    const etherscanLink = utils.getEtherScanLinkIfExists(
+        props.token.address, props.networkId, EtherscanLinkSuffixes.address,
+    );
+    const title = (
+        <div>
+            <i className="zmdi zmdi-alert-triangle" />
+            {' '}Setting allowance for unverified token{' '}
+            <i className="zmdi zmdi-alert-triangle" />
+        </div>
+    );
+    return (
+        <Dialog
+            title={title}
+            titleStyle={{fontWeight: 100}}
+            actions={[
+                <FlatButton
+                    label="Yes"
+                    onTouchTap={props.onToggleDialog.bind(this, isConfirmed)}
+                />,
+                <FlatButton
+                    label="No"
+                    onTouchTap={props.onToggleDialog.bind(this, !isConfirmed)}
+                />,
+            ]}
+            open={props.isOpen}
+            onRequestClose={props.onToggleDialog.bind(this, !isConfirmed)}
+            autoScrollBodyContent={true}
+        >
+            <div className="pt2" style={{color: colors.grey700}}>
+                <div>
+                    You are about to set an allowance to a custom token not verified
+                    by the 0x Token Registry.{' '}
+                    <b>
+                        Please be sure to verify that the token address points to the
+                        official token you think you are trading
+                    </b>:
+                </div>
+                <div className="py1">
+                    <div className="py2">
+                        {renderHex(props.token.address)}
+                    </div>
+                    <div className="center pb2">
+                        <a href={etherscanLink} target="_blank">
+                            <RaisedButton
+                                label="Verify on Etherscan"
+                            />
+                        </a>
+                    </div>
+                </div>
+                <div className="py1" style={{color: '#b51f1f'}}>
+                    Warning: setting an allowance to a malicious tokens can result in the loss of funds
+                </div>
+                <div>
+                    Are you sure you want to set an allowance for this token?
+                </div>
+            </div>
+        </Dialog>
+    );
+}
+
+function renderHex(hex: string) {
+     const hexStyle: React.CSSProperties = {
+         borderBottom: '2px solid lightgray',
+         overflow: 'hidden',
+         textOverflow: 'ellipsis',
+         whiteSpace: 'nowrap',
+     };
+     return (
+         <div className="mx-auto mt1 flex" style={{fontSize: 19, width: 462}}>
+             <div className="pr1">
+                 <CopyIcon data={hex}/>
+             </div>
+             <div
+                 style={hexStyle}
+             >
+                 {hex}
+             </div>
+         </div>
+     );
+ }

--- a/ts/components/inputs/allowance_toggle.tsx
+++ b/ts/components/inputs/allowance_toggle.tsx
@@ -7,6 +7,7 @@ import {Dispatcher} from 'ts/redux/dispatcher';
 import {Token, BalanceErrs} from 'ts/types';
 import {utils} from 'ts/utils/utils';
 import {errorReporter} from 'ts/utils/error_reporter';
+import {AllowanceConfirmationDialog} from 'ts/components/allowance_confirmation_dialog';
 
 const DEFAULT_ALLOWANCE_AMOUNT_IN_BASE_UNITS = new BigNumber(2).pow(256).minus(1);
 
@@ -16,11 +17,13 @@ interface AllowanceToggleProps {
     onErrorOccurred: (errType: BalanceErrs) => void;
     token: Token;
     userAddress: string;
+    networkId: number;
 }
 
 interface AllowanceToggleState {
     isSpinnerVisible: boolean;
     prevAllowance: BigNumber.BigNumber;
+    isConfirmationDialogVisible: boolean;
 }
 
 export class AllowanceToggle extends React.Component<AllowanceToggleProps, AllowanceToggleState> {
@@ -29,6 +32,7 @@ export class AllowanceToggle extends React.Component<AllowanceToggleProps, Allow
         this.state = {
             isSpinnerVisible: false,
             prevAllowance: props.token.allowance,
+            isConfirmationDialogVisible: false,
         };
     }
     public componentWillReceiveProps(nextProps: AllowanceToggleProps) {
@@ -54,15 +58,40 @@ export class AllowanceToggle extends React.Component<AllowanceToggleProps, Allow
                         <i className="zmdi zmdi-spinner zmdi-hc-spin" />
                     </div>
                 }
+                <AllowanceConfirmationDialog
+                    isOpen={this.state.isConfirmationDialogVisible}
+                    token={this.props.token}
+                    onToggleDialog={this.onConfirmationDialogClosedAsync.bind(this)}
+                    networkId={this.props.networkId}
+                />
             </div>
         );
+    }
+    private async onConfirmationDialogClosedAsync(isSettingAllowanceConfirmed: boolean) {
+        this.setState({
+            isConfirmationDialogVisible: false,
+        });
+        if (!isSettingAllowanceConfirmed) {
+            return;
+        }
+        await this.setAllowanceAsync();
     }
     private async onToggleAllowanceAsync() {
         if (this.props.userAddress === '') {
             this.props.dispatcher.updateShouldBlockchainErrDialogBeOpen(true);
             return false;
         }
+        const isInTokenRegistry = await this.props.blockchain.isAddressInTokenRegistryAsync(this.props.token.address);
+        if (!isInTokenRegistry && !this.isAllowanceSet()) {
+            this.setState({
+                isConfirmationDialogVisible: true,
+            });
+            return false;
+        }
 
+        await this.setAllowanceAsync();
+    }
+    private async setAllowanceAsync() {
         this.setState({
             isSpinnerVisible: true,
         });

--- a/ts/components/token_balances.tsx
+++ b/ts/components/token_balances.tsx
@@ -334,6 +334,7 @@ export class TokenBalances extends React.Component<TokenBalancesProps, TokenBala
                         token={token}
                         onErrorOccurred={this.onErrorOccurred.bind(this)}
                         userAddress={this.props.userAddress}
+                        networkId={this.props.networkId}
                     />
                 </TableRowColumn>
                 <TableRowColumn


### PR DESCRIPTION
This PR:
- Adds an additional confirmation set and warning when setting an allowance for a custom token in order to help users ensure they do not set allowances to malicious tokens.

<img width="847" alt="screen shot 2017-08-23 at 11 04 40" src="https://user-images.githubusercontent.com/2151492/29608312-0ce774be-87f4-11e7-8f3a-5017839fe353.png">
