### PR TITLE
0x.js Docs Improvements

### DIFF
--- a/ts/pages/documentation/custom_enum.tsx
+++ b/ts/pages/documentation/custom_enum.tsx
@@ -5,11 +5,14 @@ import {TypeDocNode} from 'ts/types';
 
 const STRING_ENUM_CODE_PREFIX = ' strEnum(';
 
-interface EnumProps {
+interface CustomEnumProps {
     type: TypeDocNode;
 }
 
-export function Enum(props: EnumProps) {
+// This component renders custom string enums that was a work-around for versions of
+// TypeScript <2.4.0 that did not support them natively. We keep it around to support
+// older versions of 0x.js <0.9.0
+export function CustomEnum(props: CustomEnumProps) {
     const type = props.type;
     if (!_.startsWith(type.defaultValue, STRING_ENUM_CODE_PREFIX)) {
         utils.consoleLog('We do not yet support `Variable` types that are not strEnums');

--- a/ts/pages/documentation/docs_0xjs_menu.tsx
+++ b/ts/pages/documentation/docs_0xjs_menu.tsx
@@ -6,40 +6,40 @@ import {utils} from 'ts/utils/utils';
 import {constants} from 'ts/utils/constants';
 import compareVersions = require('compare-versions');
 import {VersionDropDown} from 'ts/pages/documentation/version_drop_down';
-import {DocSections, Styles, TypeDocNode, MenuSubsectionsBySection} from 'ts/types';
+import {ZeroExJsDocSections, Styles, TypeDocNode, MenuSubsectionsBySection} from 'ts/types';
 import {typeDocUtils} from 'ts/utils/typedoc_utils';
 import {Link as ScrollLink} from 'react-scroll';
 
 export const menu = {
     introduction: [
-        DocSections.introduction,
+        ZeroExJsDocSections.introduction,
     ],
     install: [
-        DocSections.installation,
+        ZeroExJsDocSections.installation,
     ],
     topics: [
-        DocSections.async,
-        DocSections.errors,
-        DocSections.versioning,
+        ZeroExJsDocSections.async,
+        ZeroExJsDocSections.errors,
+        ZeroExJsDocSections.versioning,
     ],
     zeroEx: [
-        DocSections.zeroEx,
+        ZeroExJsDocSections.zeroEx,
     ],
     contracts: [
-        DocSections.exchange,
-        DocSections.token,
-        DocSections.tokenRegistry,
-        DocSections.etherToken,
-        DocSections.proxy,
+        ZeroExJsDocSections.exchange,
+        ZeroExJsDocSections.token,
+        ZeroExJsDocSections.tokenRegistry,
+        ZeroExJsDocSections.etherToken,
+        ZeroExJsDocSections.proxy,
     ],
     types: [
-        DocSections.types,
+        ZeroExJsDocSections.types,
     ],
 };
 
 const menuSubsectionToVersionWhenIntroduced = {
-    [DocSections.etherToken]: '0.7.1',
-    [DocSections.proxy]: '0.8.0',
+    [ZeroExJsDocSections.etherToken]: '0.7.1',
+    [ZeroExJsDocSections.proxy]: '0.8.0',
 };
 
 interface Docs0xjsMenuProps {

--- a/ts/pages/documentation/enum.tsx
+++ b/ts/pages/documentation/enum.tsx
@@ -13,12 +13,12 @@ export function Enum(props: EnumProps) {
     const values = _.map(props.values, (value, i) => {
         const isLast = i === props.values.length - 1;
         const defaultValueIfAny = !_.isUndefined(value.defaultValue) ? ` = ${value.defaultValue}` : '';
-        return `\t${value.name}${defaultValueIfAny},${!isLast ? '\n' : ''}`;
+        return `\n\t${value.name}${defaultValueIfAny},`;
     });
     return (
         <span>
             {`{`}
-                {'\n'}{values}
+                {values}
                 <br />
             {`}`}
         </span>

--- a/ts/pages/documentation/enum.tsx
+++ b/ts/pages/documentation/enum.tsx
@@ -1,0 +1,26 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import {utils} from 'ts/utils/utils';
+import {TypeDocNode, EnumValue} from 'ts/types';
+
+const STRING_ENUM_CODE_PREFIX = ' strEnum(';
+
+interface EnumProps {
+    values: EnumValue[];
+}
+
+export function Enum(props: EnumProps) {
+    const values = _.map(props.values, (value, i) => {
+        const isLast = i === props.values.length - 1;
+        const defaultValueIfAny = !_.isUndefined(value.defaultValue) ? ` = ${value.defaultValue}` : '';
+        return `\t${value.name}${defaultValueIfAny},${!isLast ? '\n' : ''}`;
+    });
+    return (
+        <span>
+            {`{`}
+                {'\n'}{values}
+                <br />
+            {`}`}
+        </span>
+    );
+}

--- a/ts/pages/documentation/type.tsx
+++ b/ts/pages/documentation/type.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import {Link as ScrollLink} from 'react-scroll';
 import {colors} from 'material-ui/styles';
+import {typeDocUtils} from 'ts/utils/typedoc_utils';
 import {constants} from 'ts/utils/constants';
 import {TypeDocType, TypeDocTypes} from 'ts/types';
 import {utils} from 'ts/utils/utils';
@@ -97,7 +98,7 @@ export function Type(props: TypeProps): any {
             </a>
         );
     } else if ((isReference || isArray) &&
-                (_.includes(constants.public0xjsTypes, typeName) ||
+                (typeDocUtils.isPublicType(typeName as string) ||
                 !_.isUndefined(sectionNameIfExists))) {
         const typeDefinitionAnchorId = _.isUndefined(sectionNameIfExists) ? typeName : sectionNameIfExists;
         typeName = (

--- a/ts/pages/documentation/type_definition.tsx
+++ b/ts/pages/documentation/type_definition.tsx
@@ -32,7 +32,7 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
     public render() {
         const type = this.props.type;
         if (!typeDocUtils.isPublicType(type.name)) {
-            return null; // Skip
+            return null; // no-op
         }
 
         let typePrefix: string;

--- a/ts/pages/documentation/type_definition.tsx
+++ b/ts/pages/documentation/type_definition.tsx
@@ -30,7 +30,7 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
     }
     public render() {
         const type = this.props.type;
-        if (!typeDocUtils.isPublicType(type)) {
+        if (!typeDocUtils.isPublicType(type.name)) {
             return null; // Skip
         }
 

--- a/ts/pages/documentation/type_definition.tsx
+++ b/ts/pages/documentation/type_definition.tsx
@@ -6,6 +6,7 @@ import {KindString, TypeDocNode, TypeDocTypes} from 'ts/types';
 import {Type} from 'ts/pages/documentation/type';
 import {Interface} from 'ts/pages/documentation/interface';
 import {CustomEnum} from 'ts/pages/documentation/custom_enum';
+import {Enum} from 'ts/pages/documentation/enum';
 import {MethodSignature} from 'ts/pages/documentation/method_signature';
 import {AnchorTitle} from 'ts/pages/documentation/anchor_title';
 import {Comment} from 'ts/pages/documentation/comment';
@@ -51,6 +52,21 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
                 codeSnippet = (
                     <CustomEnum
                         type={type}
+                    />
+                );
+                break;
+
+            case KindString.Enumeration:
+                typePrefix = 'Enum';
+                const enumValues = _.map(type.children, t => {
+                    return {
+                        name: t.name,
+                        defaultValue: t.defaultValue,
+                    };
+                });
+                codeSnippet = (
+                    <Enum
+                        values={enumValues}
                     />
                 );
                 break;

--- a/ts/pages/documentation/type_definition.tsx
+++ b/ts/pages/documentation/type_definition.tsx
@@ -5,7 +5,7 @@ import {utils} from 'ts/utils/utils';
 import {KindString, TypeDocNode, TypeDocTypes} from 'ts/types';
 import {Type} from 'ts/pages/documentation/type';
 import {Interface} from 'ts/pages/documentation/interface';
-import {Enum} from 'ts/pages/documentation/enum';
+import {CustomEnum} from 'ts/pages/documentation/custom_enum';
 import {MethodSignature} from 'ts/pages/documentation/method_signature';
 import {AnchorTitle} from 'ts/pages/documentation/anchor_title';
 import {Comment} from 'ts/pages/documentation/comment';
@@ -49,7 +49,7 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
             case KindString.Variable:
                 typePrefix = 'Enum';
                 codeSnippet = (
-                    <Enum
+                    <CustomEnum
                         type={type}
                     />
                 );

--- a/ts/pages/documentation/zero_ex_js_documentation.tsx
+++ b/ts/pages/documentation/zero_ex_js_documentation.tsx
@@ -15,7 +15,7 @@ import {
     scroller,
 } from 'react-scroll';
 import {Dispatcher} from 'ts/redux/dispatcher';
-import {KindString, TypeDocNode, DocSections, Styles, ScreenWidths, S3FileObject} from 'ts/types';
+import {KindString, TypeDocNode, ZeroExJsDocSections, Styles, ScreenWidths, S3FileObject} from 'ts/types';
 import {TopBar} from 'ts/components/top_bar';
 import {utils} from 'ts/utils/utils';
 import {constants} from 'ts/utils/constants';
@@ -41,11 +41,11 @@ const versioningMarkdown = require('md/docs/0xjs/versioning');
 const SCROLL_TO_TIMEOUT = 500;
 
 const sectionNameToMarkdown = {
-    [DocSections.introduction]: IntroMarkdown,
-    [DocSections.installation]: InstallationMarkdown,
-    [DocSections.async]: AsyncMarkdown,
-    [DocSections.errors]: ErrorsMarkdown,
-    [DocSections.versioning]: versioningMarkdown,
+    [ZeroExJsDocSections.introduction]: IntroMarkdown,
+    [ZeroExJsDocSections.installation]: InstallationMarkdown,
+    [ZeroExJsDocSections.async]: AsyncMarkdown,
+    [ZeroExJsDocSections.errors]: ErrorsMarkdown,
+    [ZeroExJsDocSections.versioning]: versioningMarkdown,
 };
 
 export interface ZeroExJSDocumentationPassedProps {
@@ -231,7 +231,7 @@ export class ZeroExJSDocumentation extends React.Component<ZeroExJSDocumentation
                     <Comment
                         comment={packageComment}
                     />
-                    {sectionName === DocSections.zeroEx && constructors.length > 0 &&
+                    {sectionName === ZeroExJsDocSections.zeroEx && constructors.length > 0 &&
                         <div>
                             <h2 className="thin">Constructor</h2>
                             {this.renderZeroExConstructors(constructors)}
@@ -263,7 +263,7 @@ export class ZeroExJSDocumentation extends React.Component<ZeroExJSDocumentation
     private renderZeroExConstructors(constructors: TypeDocNode[]): React.ReactNode {
         const isConstructor = true;
         const constructorDefs = _.map(constructors, constructor => {
-            return this.renderMethodBlocks(constructor, DocSections.zeroEx, isConstructor);
+            return this.renderMethodBlocks(constructor, ZeroExJsDocSections.zeroEx, isConstructor);
         });
         return (
             <div>
@@ -302,7 +302,7 @@ export class ZeroExJSDocumentation extends React.Component<ZeroExJSDocumentation
             // Hack: currently the section names are identical as the property names on the ZeroEx class
             // For now we reply on this mapping to construct the method entity. In the future, we should
             // do this differently.
-            entity = (sectionName !== DocSections.zeroEx) ? `${entity}${sectionName}.` : entity;
+            entity = (sectionName !== ZeroExJsDocSections.zeroEx) ? `${entity}${sectionName}.` : entity;
             entity = isConstructor ? '' : entity;
             return (
                 <MethodBlock

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -348,7 +348,7 @@ export const TypeDocTypes = strEnum([
 ]);
 export type TypeDocTypes = keyof typeof TypeDocTypes;
 
-export const DocSections = strEnum([
+export const ZeroExJsDocSections = strEnum([
   'introduction',
   'installation',
   'async',
@@ -362,7 +362,7 @@ export const DocSections = strEnum([
   'proxy',
   'types',
 ]);
-export type DocSections = keyof typeof DocSections;
+export type ZeroExJsDocSections = keyof typeof ZeroExJsDocSections;
 
 interface CivicSignupOpts {
     style: string;

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -284,8 +284,14 @@ export const KindString = strEnum([
   'Type alias',
   'Variable',
   'Function',
+  'Enumeration',
 ]);
 export type KindString = keyof typeof KindString;
+
+export interface EnumValue {
+    name: string;
+    defaultValue?: string;
+}
 
 export enum Environments {
     DEVELOPMENT,

--- a/ts/utils/typedoc_utils.ts
+++ b/ts/utils/typedoc_utils.ts
@@ -1,20 +1,20 @@
 import * as _ from 'lodash';
 import {constants} from 'ts/utils/constants';
-import {TypeDocNode, KindString, DocSections, MenuSubsectionsBySection} from 'ts/types';
+import {TypeDocNode, KindString, ZeroExJsDocSections, MenuSubsectionsBySection} from 'ts/types';
 
 const TYPES_MODULE_PATH = '"src/types"';
 
 export const sectionNameToPossibleModulePaths: {[name: string]: string[]} = {
-    [DocSections.zeroEx]: ['"src/0x"'],
-    [DocSections.exchange]: ['"src/contract_wrappers/exchange_wrapper"'],
-    [DocSections.tokenRegistry]: ['"src/contract_wrappers/token_registry_wrapper"'],
-    [DocSections.token]: ['"src/contract_wrappers/token_wrapper"'],
-    [DocSections.etherToken]: ['"src/contract_wrappers/ether_token_wrapper"'],
-    [DocSections.proxy]: [
+    [ZeroExJsDocSections.zeroEx]: ['"src/0x"'],
+    [ZeroExJsDocSections.exchange]: ['"src/contract_wrappers/exchange_wrapper"'],
+    [ZeroExJsDocSections.tokenRegistry]: ['"src/contract_wrappers/token_registry_wrapper"'],
+    [ZeroExJsDocSections.token]: ['"src/contract_wrappers/token_wrapper"'],
+    [ZeroExJsDocSections.etherToken]: ['"src/contract_wrappers/ether_token_wrapper"'],
+    [ZeroExJsDocSections.proxy]: [
         '"src/contract_wrappers/proxy_wrapper"',
         '"src/contract_wrappers/token_transfer_proxy_wrapper"',
     ],
-    [DocSections.types]: [TYPES_MODULE_PATH],
+    [ZeroExJsDocSections.types]: [TYPES_MODULE_PATH],
 };
 
 export const typeDocUtils = {
@@ -55,12 +55,12 @@ export const typeDocUtils = {
         if (_.isUndefined(versionDocObj)) {
             return menuSubsectionsBySection;
         }
-        const docSections = _.keys(DocSections);
+        const docSections = _.keys(ZeroExJsDocSections);
         _.each(docSections, menuItemName => {
             // Since the `types.ts` file is the only file that does not export a module/class but
             // instead has each type export itself, we do not need to go down two levels of nesting
             // for it.
-            if (menuItemName === DocSections.types) {
+            if (menuItemName === ZeroExJsDocSections.types) {
                 const allModules = versionDocObj.children;
                 const typesModule = _.find(allModules, {name: TYPES_MODULE_PATH}) as TypeDocNode;
                 const allTypes = _.filter(typesModule.children, typeDocUtils.isType);

--- a/ts/utils/typedoc_utils.ts
+++ b/ts/utils/typedoc_utils.ts
@@ -36,8 +36,8 @@ export const typeDocUtils = {
     isPrivateOrProtectedProperty(propertyName: string): boolean {
         return _.startsWith(propertyName, '_');
     },
-    isPublicType(type: TypeDocNode): boolean {
-        return _.includes(constants.public0xjsTypes, type.name);
+    isPublicType(typeName: string): boolean {
+        return _.includes(constants.public0xjsTypes, typeName);
     },
     getModuleDefinitionBySectionNameIfExists(versionDocObj: TypeDocNode, sectionName: string): TypeDocNode|undefined {
         const possibleModulePathNames = sectionNameToPossibleModulePaths[sectionName];
@@ -64,7 +64,9 @@ export const typeDocUtils = {
                 const allModules = versionDocObj.children;
                 const typesModule = _.find(allModules, {name: TYPES_MODULE_PATH}) as TypeDocNode;
                 const allTypes = _.filter(typesModule.children, typeDocUtils.isType);
-                const publicTypes = _.filter(allTypes, typeDocUtils.isPublicType);
+                const publicTypes = _.filter(allTypes, type => {
+                    return typeDocUtils.isPublicType(type.name);
+                });
                 menuSubsectionsBySection[menuItemName] = publicTypes;
             } else {
                 const moduleDefinition = typeDocUtils.getModuleDefinitionBySectionNameIfExists(

--- a/ts/utils/typedoc_utils.ts
+++ b/ts/utils/typedoc_utils.ts
@@ -22,7 +22,8 @@ export const typeDocUtils = {
         return entity.kindString === KindString.Interface ||
                entity.kindString === KindString.Function ||
                entity.kindString === KindString['Type alias'] ||
-               entity.kindString === KindString.Variable;
+               entity.kindString === KindString.Variable ||
+               entity.kindString === KindString.Enumeration;
     },
     isMethod(entity: TypeDocNode): boolean {
         return entity.kindString === KindString.Method;


### PR DESCRIPTION
This PR:
- Adds support for displaying TypeScript 2.4.0 string enum types
- Renames Enum to CustomEnum and adds comment explaining that it's used to display legacy string enums.
- Renames variables for clarity and changes a few react component interfaces to prepare for supporting Solidity documentation.