### PR TITLE
Refactor 0x.js Docs to use DocAgnosticFormat rather then TypeDoc specific JSON

### DIFF
--- a/ts/pages/documentation/custom_enum.tsx
+++ b/ts/pages/documentation/custom_enum.tsx
@@ -1,12 +1,12 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import {utils} from 'ts/utils/utils';
-import {TypeDocNode} from 'ts/types';
+import {CustomType} from 'ts/types';
 
 const STRING_ENUM_CODE_PREFIX = ' strEnum(';
 
 interface CustomEnumProps {
-    type: TypeDocNode;
+    type: CustomType;
 }
 
 // This component renders custom string enums that was a work-around for versions of

--- a/ts/pages/documentation/interface.tsx
+++ b/ts/pages/documentation/interface.tsx
@@ -1,11 +1,11 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import {TypeDocNode, TypeDocTypes} from 'ts/types';
+import {CustomType, TypeDocTypes} from 'ts/types';
 import {Type} from 'ts/pages/documentation/type';
 import {MethodSignature} from 'ts/pages/documentation/method_signature';
 
 interface InterfaceProps {
-    type: TypeDocNode;
+    type: CustomType;
 }
 
 export function Interface(props: InterfaceProps) {
@@ -14,10 +14,10 @@ export function Interface(props: InterfaceProps) {
         return (
             <span key={`property-${property.name}-${property.type}-${type.name}`}>
                 {property.name}:{' '}
-                {property.type.type !== TypeDocTypes.reflection ?
+                {property.type.typeDocType !== TypeDocTypes.reflection ?
                     <Type type={property.type} /> :
                     <MethodSignature
-                        signature={property.type.declaration.signatures[0]}
+                        method={property.type.method}
                         shouldHideMethodName={true}
                         shouldUseArrowSyntax={true}
                     />
@@ -27,20 +27,17 @@ export function Interface(props: InterfaceProps) {
     });
     const hasIndexSignature = !_.isUndefined(type.indexSignature);
     if (hasIndexSignature) {
-        _.each(type.indexSignature, indexSignature => {
-            const params = _.map(indexSignature.parameters, p => {
-                return (
-                    <span key={`indexSigParams-${p.name}-${p.type}-${type.name}`}>
-                        {p.name}: <Type type={p.type} />
-                    </span>
-                );
-            });
-            properties.push((
-                <span key={`indexSignature-${type.name}-${indexSignature.type.name}`}>
-                    [{params}]: {indexSignature.type.name},
-                </span>
-            ));
-        });
+        const is = type.indexSignature;
+        const param = (
+            <span key={`indexSigParams-${is.keyName}-${is.keyType}-${type.name}`}>
+                {is.keyName}: <Type type={is.keyType} />
+            </span>
+        );
+        properties.push((
+            <span key={`indexSignature-${type.name}-${is.keyType.name}`}>
+                [{param}]: {is.valueName},
+            </span>
+        ));
     }
     const propertyList = _.reduce(properties, (prev: React.ReactNode, curr: React.ReactNode) => {
         return [prev, '\n\t', curr];

--- a/ts/pages/documentation/method_block.tsx
+++ b/ts/pages/documentation/method_block.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as ReactMarkdown from 'react-markdown';
 import {Chip} from 'material-ui/Chip';
 import {colors} from 'material-ui/styles';
-import {TypeDocNode, Styles, TypeDefinitionByName} from 'ts/types';
+import {TypeDocNode, Styles, TypeDefinitionByName, Method, Parameter} from 'ts/types';
 import {utils} from 'ts/utils/utils';
 import {SourceLink} from 'ts/pages/documentation/source_link';
 import {MethodSignature} from 'ts/pages/documentation/method_signature';
@@ -12,11 +12,7 @@ import {Comment} from 'ts/pages/documentation/comment';
 import {typeDocUtils} from 'ts/utils/typedoc_utils';
 
 interface MethodBlockProps {
-    isConstructor: boolean;
-    isStatic: boolean;
-    methodSignature: TypeDocNode;
-    source: TypeDocNode;
-    entity: string;
+    method: Method;
     libraryVersion: string;
     typeDefinitionByName: TypeDefinitionByName;
 }
@@ -45,22 +41,22 @@ export class MethodBlock extends React.Component<MethodBlockProps, MethodBlockSt
         };
     }
     public render() {
-        const methodSignature = this.props.methodSignature;
-        if (typeDocUtils.isPrivateOrProtectedProperty(methodSignature.name)) {
+        const method = this.props.method;
+        if (typeDocUtils.isPrivateOrProtectedProperty(method.name)) {
             return null;
         }
 
         return (
             <div
-                id={methodSignature.name}
+                id={method.name}
                 style={{overflow: 'hidden', width: '100%'}}
                 className="pb4"
                 onMouseOver={this.setAnchorVisibility.bind(this, true)}
                 onMouseOut={this.setAnchorVisibility.bind(this, false)}
             >
-                {!this.props.isConstructor &&
+                {!method.isConstructor &&
                     <div className="flex">
-                        {this.props.isStatic &&
+                        {method.isStatic &&
                             <div
                                 className="p1 mr1"
                                 style={styles.chip}
@@ -70,30 +66,29 @@ export class MethodBlock extends React.Component<MethodBlockProps, MethodBlockSt
                          }
                         <AnchorTitle
                             headerType="h3"
-                            title={methodSignature.name}
-                            id={methodSignature.name}
+                            title={method.name}
+                            id={method.name}
                             shouldShowAnchor={this.state.shouldShowAnchor}
                         />
                     </div>
                 }
                 <code className="hljs">
                     <MethodSignature
-                        signature={methodSignature}
-                        entity={this.props.entity}
+                        method={method}
                         typeDefinitionByName={this.props.typeDefinitionByName}
                     />
                 </code>
                 <SourceLink
                     version={this.props.libraryVersion}
-                    source={this.props.source}
+                    source={method.source}
                 />
-                {methodSignature.comment &&
+                {method.comment &&
                     <Comment
-                        comment={methodSignature.comment.shortText}
+                        comment={method.comment}
                         className="py2"
                     />
                 }
-                {methodSignature.parameters &&
+                {method.parameters &&
                     <div>
                         <h4
                             className="pb1 thin"
@@ -101,10 +96,10 @@ export class MethodBlock extends React.Component<MethodBlockProps, MethodBlockSt
                         >
                             ARGUMENTS
                         </h4>
-                        {this.renderParameterDescriptions(methodSignature.parameters)}
+                        {this.renderParameterDescriptions(method.parameters)}
                     </div>
                 }
-                {methodSignature.comment && methodSignature.comment.returns &&
+                {method.returnComment &&
                     <div className="pt1 comment">
                         <h4
                             className="pb1 thin"
@@ -113,22 +108,16 @@ export class MethodBlock extends React.Component<MethodBlockProps, MethodBlockSt
                             RETURNS
                         </h4>
                         <Comment
-                            comment={methodSignature.comment.returns}
+                            comment={method.returnComment}
                         />
                     </div>
                 }
             </div>
         );
     }
-    private renderParameterDescriptions(parameters: TypeDocNode[]) {
+    private renderParameterDescriptions(parameters: Parameter[]) {
         const descriptions = _.map(parameters, parameter => {
-            let comment = '<No comment>';
-            if (parameter.comment && parameter.comment.shortText) {
-                comment = parameter.comment.shortText;
-            } else if (parameter.comment && parameter.comment.text) {
-                comment = parameter.comment.text;
-            }
-            const isOptional = parameter.flags.isOptional;
+            const isOptional = parameter.isOptional;
             return (
                 <div
                     key={`param-description-${parameter.name}`}
@@ -146,7 +135,7 @@ export class MethodBlock extends React.Component<MethodBlockProps, MethodBlockSt
                     </div>
                     <div className="col lg-col-8 md-col-8 sm-col-12 col-12">
                         <Comment
-                            comment={comment}
+                            comment={parameter.comment}
                         />
                     </div>
                 </div>

--- a/ts/pages/documentation/method_signature.tsx
+++ b/ts/pages/documentation/method_signature.tsx
@@ -1,11 +1,10 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import {TypeDocNode, TypeDefinitionByName} from 'ts/types';
+import {Method, TypeDefinitionByName, Parameter} from 'ts/types';
 import {Type} from 'ts/pages/documentation/type';
 
 interface MethodSignatureProps {
-    signature: TypeDocNode;
-    entity?: string;
+    method: Method;
     shouldHideMethodName?: boolean;
     shouldUseArrowSyntax?: boolean;
     typeDefinitionByName?: TypeDefinitionByName;
@@ -14,27 +13,26 @@ interface MethodSignatureProps {
 const defaultProps = {
     shouldHideMethodName: false,
     shouldUseArrowSyntax: false,
-    entity: '',
 };
 
 export const MethodSignature: React.SFC<MethodSignatureProps> = (props: MethodSignatureProps) => {
-    const parameters = renderParameters(props.signature, props.typeDefinitionByName);
+    const parameters = renderParameters(props.method, props.typeDefinitionByName);
     const paramString = _.reduce(parameters, (prev: React.ReactNode, curr: React.ReactNode) => {
         return [prev, ', ', curr];
     });
-    const methodName = props.shouldHideMethodName ? '' : props.signature.name;
+    const methodName = props.shouldHideMethodName ? '' : props.method.name;
     return (
         <span>
-            {props.entity}{methodName}({paramString}){props.shouldUseArrowSyntax ? ' => ' : ': '}
-            {' '}<Type type={props.signature.type} typeDefinitionByName={props.typeDefinitionByName}/>
+            {props.method.callPath}{methodName}({paramString}){props.shouldUseArrowSyntax ? ' => ' : ': '}
+            {' '}<Type type={props.method.returnType} typeDefinitionByName={props.typeDefinitionByName}/>
         </span>
     );
 };
 
-function renderParameters(signature: TypeDocNode, typeDefinitionByName?: TypeDefinitionByName) {
-    const parameters = signature.parameters;
-    const params = _.map(parameters, p => {
-        const isOptional = p.flags.isOptional;
+function renderParameters(method: Method, typeDefinitionByName?: TypeDefinitionByName) {
+    const parameters = method.parameters;
+    const params = _.map(parameters, (p: Parameter) => {
+        const isOptional = p.isOptional;
         return (
             <span key={`param-${p.type}-${p.name}`}>
                 {p.name}{isOptional && '?'}: <Type type={p.type} typeDefinitionByName={typeDefinitionByName}/>

--- a/ts/pages/documentation/source_link.tsx
+++ b/ts/pages/documentation/source_link.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {colors} from 'material-ui/styles';
-import {TypeDocNode} from 'ts/types';
+import {Source} from 'ts/types';
 import {constants} from 'ts/utils/constants';
 
 interface SourceLinkProps {
-    source: TypeDocNode;
+    source: Source;
     version: string;
 }
 

--- a/ts/pages/documentation/type.tsx
+++ b/ts/pages/documentation/type.tsx
@@ -5,7 +5,7 @@ import * as ReactTooltip from 'react-tooltip';
 import {colors} from 'material-ui/styles';
 import {typeDocUtils} from 'ts/utils/typedoc_utils';
 import {constants} from 'ts/utils/constants';
-import {TypeDocType, TypeDocTypes, TypeDefinitionByName} from 'ts/types';
+import {Type as TypeDef, TypeDocTypes, TypeDefinitionByName} from 'ts/types';
 import {utils} from 'ts/utils/utils';
 import {TypeDefinition} from 'ts/pages/documentation/type_definition';
 
@@ -29,7 +29,7 @@ const typeToSection: {[typeName: string]: string} = {
 };
 
 interface TypeProps {
-    type: TypeDocType;
+    type: TypeDef;
     typeDefinitionByName?: TypeDefinitionByName;
 }
 
@@ -37,14 +37,14 @@ interface TypeProps {
 // <Type /> components (e.g when rendering the union type).
 export function Type(props: TypeProps): any {
     const type = props.type;
-    const isIntrinsic = type.type === TypeDocTypes.intrinsic;
-    const isReference = type.type === TypeDocTypes.reference;
-    const isArray = type.type === TypeDocTypes.array;
-    const isStringLiteral = type.type === TypeDocTypes.stringLiteral;
+    const isIntrinsic = type.typeDocType === TypeDocTypes.intrinsic;
+    const isReference = type.typeDocType === TypeDocTypes.reference;
+    const isArray = type.typeDocType === TypeDocTypes.array;
+    const isStringLiteral = type.typeDocType === TypeDocTypes.stringLiteral;
     let typeNameColor = 'inherit';
     let typeName: string|React.ReactNode;
     let typeArgs: React.ReactNode[] = [];
-    switch (type.type) {
+    switch (type.typeDocType) {
         case TypeDocTypes.intrinsic:
             typeName = type.name;
             typeNameColor = BUILT_IN_TYPE_COLOR;
@@ -52,25 +52,27 @@ export function Type(props: TypeProps): any {
 
         case TypeDocTypes.reference:
             typeName = type.name;
-            typeArgs = _.map(type.typeArguments, arg => {
-                if (arg.type === TypeDocTypes.array) {
+            typeArgs = _.map(type.typeArguments, (arg: TypeDef) => {
+                if (arg.typeDocType === TypeDocTypes.array) {
+                    const key = `type-${arg.elementType.name}-${arg.elementType.typeDocType}`;
                     return (
                         <span>
                             <Type
-                                key={`type-${arg.elementType.name}-${arg.elementType.value}-${arg.elementType.type}`}
+                                key={key}
                                 type={arg.elementType}
                                 typeDefinitionByName={props.typeDefinitionByName}
                             />[]
                         </span>
                     );
                 } else {
-                    return (
+                    const subType = (
                         <Type
-                            key={`type-${arg.name}-${arg.value}-${arg.type}`}
+                            key={`type-${arg.name}-${arg.value}-${arg.typeDocType}`}
                             type={arg}
                             typeDefinitionByName={props.typeDefinitionByName}
                         />
                     );
+                    return subType;
                 }
             });
             break;
@@ -88,7 +90,7 @@ export function Type(props: TypeProps): any {
             const unionTypes = _.map(type.types, t => {
                 return (
                     <Type
-                        key={`type-${t.name}-${t.value}-${t.type}`}
+                        key={`type-${t.name}-${t.value}-${t.typeDocType}`}
                         type={t}
                         typeDefinitionByName={props.typeDefinitionByName}
                     />
@@ -100,7 +102,7 @@ export function Type(props: TypeProps): any {
             break;
 
         default:
-            throw utils.spawnSwitchErr('type.type', type.type);
+            throw utils.spawnSwitchErr('type.typeDocType', type.typeDocType);
     }
     // HACK: Normalize BigNumber.BigNumber to simply BigNumber. For some reason the type
     // name is unpredictably one or the other.
@@ -160,7 +162,7 @@ export function Type(props: TypeProps): any {
                         id={id}
                         className="typeTooltip"
                     >
-                        <TypeDefinition type={typeDefinition} shouldAddId={false} />
+                        <TypeDefinition customType={typeDefinition} shouldAddId={false} />
                     </ReactTooltip>
                 </span>
             }

--- a/ts/pages/documentation/type_definition.tsx
+++ b/ts/pages/documentation/type_definition.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import {constants} from 'ts/utils/constants';
 import {utils} from 'ts/utils/utils';
-import {KindString, TypeDocNode, TypeDocTypes} from 'ts/types';
+import {KindString, CustomType, TypeDocTypes, CustomTypeChild} from 'ts/types';
 import {Type} from 'ts/pages/documentation/type';
 import {Interface} from 'ts/pages/documentation/interface';
 import {CustomEnum} from 'ts/pages/documentation/custom_enum';
@@ -15,7 +15,7 @@ import {typeDocUtils} from 'ts/utils/typedoc_utils';
 const KEYWORD_COLOR = '#a81ca6';
 
 interface TypeDefinitionProps {
-    type: TypeDocNode;
+    customType: CustomType;
     shouldAddId?: boolean;
 }
 
@@ -34,19 +34,19 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
         };
     }
     public render() {
-        const type = this.props.type;
-        if (!typeDocUtils.isPublicType(type.name)) {
+        const customType = this.props.customType;
+        if (!typeDocUtils.isPublicType(customType.name)) {
             return null; // no-op
         }
 
         let typePrefix: string;
         let codeSnippet: React.ReactNode;
-        switch (type.kindString) {
+        switch (customType.kindString) {
             case KindString.Interface:
                 typePrefix = 'Interface';
                 codeSnippet = (
                     <Interface
-                        type={type}
+                        type={customType}
                     />
                 );
                 break;
@@ -55,17 +55,17 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
                 typePrefix = 'Enum';
                 codeSnippet = (
                     <CustomEnum
-                        type={type}
+                        type={customType}
                     />
                 );
                 break;
 
             case KindString.Enumeration:
                 typePrefix = 'Enum';
-                const enumValues = _.map(type.children, t => {
+                const enumValues = _.map(customType.children, (c: CustomTypeChild) => {
                     return {
-                        name: t.name,
-                        defaultValue: t.defaultValue,
+                        name: c.name,
+                        defaultValue: c.defaultValue,
                     };
                 });
                 codeSnippet = (
@@ -79,11 +79,11 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
                 typePrefix = 'Type Alias';
                 codeSnippet = (
                     <span>
-                        <span style={{color: KEYWORD_COLOR}}>type</span> {type.name} ={' '}
-                        {type.type.type !== TypeDocTypes.reflection ?
-                            <Type type={type.type} /> :
+                        <span style={{color: KEYWORD_COLOR}}>type</span> {customType.name} ={' '}
+                        {customType.type.typeDocType !== TypeDocTypes.reflection ?
+                            <Type type={customType.type} /> :
                             <MethodSignature
-                                signature={type.type.declaration.signatures[0]}
+                                method={customType.type.method}
                                 shouldHideMethodName={true}
                                 shouldUseArrowSyntax={true}
                             />
@@ -93,10 +93,10 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
                 break;
 
             default:
-                throw utils.spawnSwitchErr('type.kindString', type.kindString);
+                throw utils.spawnSwitchErr('type.kindString', customType.kindString);
         }
 
-        const typeDefinitionAnchorId = type.name;
+        const typeDefinitionAnchorId = customType.name;
         return (
             <div
                 id={this.props.shouldAddId ? typeDefinitionAnchorId : ''}
@@ -107,7 +107,7 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
             >
                 <AnchorTitle
                     headerType="h3"
-                    title={`${typePrefix} ${type.name}`}
+                    title={`${typePrefix} ${customType.name}`}
                     id={this.props.shouldAddId ? typeDefinitionAnchorId : ''}
                     shouldShowAnchor={this.state.shouldShowAnchor}
                 />
@@ -118,9 +118,9 @@ export class TypeDefinition extends React.Component<TypeDefinitionProps, TypeDef
                         </code>
                     </pre>
                 </div>
-                {type.comment &&
+                {customType.comment &&
                     <Comment
-                        comment={type.comment.shortText}
+                        comment={customType.comment}
                         className="py2"
                     />
                 }

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -368,6 +368,87 @@ export const TypeDocTypes = strEnum([
 ]);
 export type TypeDocTypes = keyof typeof TypeDocTypes;
 
+export interface DocAgnosticFormat {
+    [sectionName: string]: DocSection;
+}
+
+export interface DocSection {
+    comment: string;
+    constructors: Method[];
+    methods: Method[];
+    properties: Property[];
+    types: CustomType[];
+}
+
+export interface Property {
+    name: string;
+    type: Type;
+    source: Source;
+    comment?: string;
+}
+
+export interface Method {
+    isStatic: boolean;
+    isConstructor: boolean;
+    name: string;
+    comment?: string;
+    returnComment?: string|undefined;
+    source: Source;
+    callPath: string;
+    parameters: Parameter[];
+    returnType: Type;
+}
+
+export interface Source {
+    fileName: string;
+    line: number;
+}
+
+export interface Parameter {
+    name: string;
+    comment: string;
+    isOptional: boolean;
+    type: Type;
+}
+
+export interface Type {
+    name: string;
+    typeDocType: TypeDocTypes;
+    value?: string;
+    typeArguments?: Type[];
+    elementType?: ElementType;
+    types?: Type[];
+    method?: Method;
+}
+
+export interface ElementType {
+    name: string;
+    typeDocType: TypeDocTypes;
+}
+
+export interface IndexSignature {
+    keyName: string;
+    keyType: Type;
+    valueName: string;
+}
+
+export interface CustomType {
+    name: string;
+    kindString: string;
+    type?: Type;
+    method?: Method;
+    indexSignature?: IndexSignature;
+    defaultValue?: string;
+    comment?: string;
+    children?: CustomTypeChild[];
+}
+
+export interface CustomTypeChild {
+    name: string;
+    type?: Type;
+    defaultValue?: string;
+}
+
 export const ZeroExJsDocSections = strEnum([
   'introduction',
   'installation',
@@ -487,7 +568,7 @@ export interface BlogPost {
 }
 
 export interface TypeDefinitionByName {
-    [typeName: string]: TypeDocNode;
+    [typeName: string]: CustomType;
 }
 
 export interface Article {

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -466,16 +466,6 @@ export const ZeroExJsDocSections = strEnum([
 ]);
 export type ZeroExJsDocSections = keyof typeof ZeroExJsDocSections;
 
-interface CivicSignupOpts {
-    style: string;
-    scopeRequest: string;
-}
-export interface CivicSip {
-    ScopeRequests: any;
-    signup: (opts: CivicSignupOpts) => void;
-    on: (eventName: string, callback: (event: any) => void) => void;
-}
-
 export interface FAQQuestion {
     prompt: string;
     answer: React.ReactNode;


### PR DESCRIPTION
Start by reviewing `types.ts`, and then `typeDoc_utils.ts`.

This PR:
- Refactor 0x.js Docs to use DocAgnostic format rather then TypeDoc specific JSON
- Introduces a bunch of more specific types for methods, properties, types that are much more specific then simply passing a TypeDocNode everywhere
- Removes some unused types