### PR TITLE
Remove Async and Sync types for EventCallback

### DIFF
--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -159,8 +159,6 @@ export const constants = {
         'ECSignature',
         'ZeroExError',
         'EventCallback',
-        'EventCallbackAsync',
-        'EventCallbackSync',
         'ExchangeContractErrs',
         'ContractEvent',
         'Token',


### PR DESCRIPTION
Remove Async and Sync types for EventCallback as they have been consolidated and Async has been removed.