### PR TITLE
Add jsx-no-lambda rule to TSLint config

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
         "completed-docs": false,
         "prefer-function-over-method": false,
         "custom-no-magic-numbers": false,
-        "semicolon": [true, "always", "ignore-bound-class-methods"]
+        "semicolon": [true, "always", "ignore-bound-class-methods"],
+        "jsx-no-lambda": false
     }
 }


### PR DESCRIPTION
When creating functional components in React I ran into a TSLint issue:

`Lambdas are forbidden in JSX attributes due to their rendering performance impact`

This happens when you add an inline function in a JSX attribute:

```
<Tab
    isSelected={selectedTabIndex === 0}
    onClick={() => setSelectedTabIndex(0)}
>
```

When you need to pass data (for example an index or id) to the function, a lambda like this seems unavoidable (data attributes could work but add code complexity). 

The consensus in [this thread](https://github.com/palantir/tslint-react/issues/96) seems to be that it’s ok to add the `jsx-no-lambda` to `tslint.json`.