### PR TITLE
Add trading pair types

### DIFF
--- a/ts/types.ts
+++ b/ts/types.ts
@@ -731,6 +731,24 @@ export interface WebsiteBackendTradingPairs {
     tradingPairs: WebsiteBackendTradingPair[];
 }
 
+export interface StakingPoolMetrics {
+    totalVolume: string;
+    totalStaked: string;
+    feesGenerated: string;
+    rewardsShared: string;
+}
+
+export interface WebsiteBackendStakingPoolInfo {
+    // 0x1234...1234 <= is this the id?
+    id: string;
+    website: string;
+    rewardsShared: number;
+    iconUrl: string;
+    estimatedStake: number;
+    currentEpochMetrics: StakingPoolMetrics;
+    allTimeMetrics: StakingPoolMetrics;
+}
+
 export interface ExchangeSlippageData {
     exchange: string;
     slippage: string;

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -749,6 +749,18 @@ export interface WebsiteBackendStakingPoolInfo {
     allTimeMetrics: StakingPoolMetrics;
 }
 
+export interface StakingHistoryDataset {
+    // 'Fees collected' or 'Rewards shared'
+    title: string;
+    data: StakingHistoryTimePoint[];
+}
+
+export interface StakingHistoryTimePoint {
+    date: string;
+    value: number;
+    epoch: string;
+}
+
 export interface ExchangeSlippageData {
     exchange: string;
     slippage: string;

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -745,6 +745,7 @@ export interface WebsiteBackendStakingPoolInfo {
     rewardsShared: number;
     iconUrl: string;
     estimatedStake: number;
+    nextEpoch: string;
     currentEpochMetrics: StakingPoolMetrics;
     allTimeMetrics: StakingPoolMetrics;
 }

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -712,6 +712,25 @@ export interface WebsiteBackendJobInfo {
     url: string;
 }
 
+export interface WebsiteBackendCurrency {
+    name: string;
+    iconUrl: string;
+}
+
+export interface WebsiteBackendTradingPair {
+    id: string;
+    price: string;
+    currency: string;
+    firstCurrency: WebsiteBackendCurrency;
+    secondCurrency: WebsiteBackendCurrency;
+    // Is there a link to a trading pair detail url?
+    url: string;
+}
+
+export interface WebsiteBackendTradingPairs {
+    tradingPairs: WebsiteBackendTradingPair[];
+}
+
 export interface ExchangeSlippageData {
     exchange: string;
     slippage: string;

--- a/ts/utils/backend_client.ts
+++ b/ts/utils/backend_client.ts
@@ -8,6 +8,7 @@ import {
     WebsiteBackendRelayerInfo,
     WebsiteBackendTokenInfo,
     WebsiteBackendTradingPairs,
+    WebsiteBackendStakingPoolInfo,
 } from 'ts/types';
 import { fetchUtils } from 'ts/utils/fetch_utils';
 import { utils } from 'ts/utils/utils';
@@ -20,6 +21,7 @@ const TOKENS_ENDPOINT = '/tokens';
 const CFL_METRICS_ENDPOINT = '/cfl-metrics';
 const SUBSCRIBE_SUBSTACK_NEWSLETTER_ENDPOINT = '/newsletter_subscriber/substack';
 const TRADING_PAIRS_ENDPOINT = '/trading-pairs';
+const STAKING_POOLS_ENDPOINT = '/staking-pools';
 
 export const backendClient = {
     async getGasInfoAsync(): Promise<WebsiteBackendGasInfo> {
@@ -61,5 +63,11 @@ export const backendClient = {
     },
     async getTradingPairsAsync(): Promise<WebsiteBackendTradingPairs[]> {
         return fetchUtils.requestAsync(utils.getBackendBaseUrl(), TRADING_PAIRS_ENDPOINT);
+    },
+    async getStakingPoolsAsync(): Promise<WebsiteBackendStakingPoolInfo[]> {
+        return fetchUtils.requestAsync(utils.getBackendBaseUrl(), STAKING_POOLS_ENDPOINT);
+    },
+    async getStakingPoolAsync(id: string): Promise<WebsiteBackendStakingPoolInfo> {
+        return fetchUtils.requestAsync(utils.getBackendBaseUrl(), `${STAKING_POOLS_ENDPOINT}/${id}`);
     },
 };

--- a/ts/utils/backend_client.ts
+++ b/ts/utils/backend_client.ts
@@ -7,6 +7,7 @@ import {
     WebsiteBackendPriceInfo,
     WebsiteBackendRelayerInfo,
     WebsiteBackendTokenInfo,
+    WebsiteBackendTradingPairs,
 } from 'ts/types';
 import { fetchUtils } from 'ts/utils/fetch_utils';
 import { utils } from 'ts/utils/utils';
@@ -18,6 +19,7 @@ const RELAYERS_ENDPOINT = '/relayers';
 const TOKENS_ENDPOINT = '/tokens';
 const CFL_METRICS_ENDPOINT = '/cfl-metrics';
 const SUBSCRIBE_SUBSTACK_NEWSLETTER_ENDPOINT = '/newsletter_subscriber/substack';
+const TRADING_PAIRS_ENDPOINT = '/trading-pairs';
 
 export const backendClient = {
     async getGasInfoAsync(): Promise<WebsiteBackendGasInfo> {
@@ -56,5 +58,8 @@ export const backendClient = {
     },
     async getCFLMetricsAsync(): Promise<WebsiteBackendCFLMetricsData> {
         return fetchUtils.requestAsync(utils.getBackendBaseUrl(), CFL_METRICS_ENDPOINT);
+    },
+    async getTradingPairsAsync(): Promise<WebsiteBackendTradingPairs[]> {
+        return fetchUtils.requestAsync(utils.getBackendBaseUrl(), TRADING_PAIRS_ENDPOINT);
     },
 };

--- a/ts/utils/backend_client.ts
+++ b/ts/utils/backend_client.ts
@@ -6,9 +6,9 @@ import {
     WebsiteBackendJobInfo,
     WebsiteBackendPriceInfo,
     WebsiteBackendRelayerInfo,
+    WebsiteBackendStakingPoolInfo,
     WebsiteBackendTokenInfo,
     WebsiteBackendTradingPairs,
-    WebsiteBackendStakingPoolInfo,
 } from 'ts/types';
 import { fetchUtils } from 'ts/utils/fetch_utils';
 import { utils } from 'ts/utils/utils';


### PR DESCRIPTION
Hi David,

I’ve set up a basic type for the trading pairs as shown on the Market Maker Profile page: 

<img width="1048" alt="Screenshot 2019-09-27 at 11 56 00" src="https://user-images.githubusercontent.com/2734703/65760740-d8da5800-e11d-11e9-9f1e-2d5b4f1f5155.png">

I will update this pull request with more types, but this way we can agree on a format ;-)
