### PR TITLE
[WIP] Adding types and general wrapper for staking API

### DIFF
--- a/ts/staking_client.ts
+++ b/ts/staking_client.ts
@@ -1,0 +1,69 @@
+import { BigNumber } from '@0x/utils';
+import * as _ from 'lodash';
+
+import { DetailedStakingPoolStats, StakingDelegatorStats, StakingPoolStats, StakingStats } from './staking_types';
+
+const STANDARD_STAKING_API_ENDPOINTS = {
+    STAKING: '/staking',
+    STAKING_POOL: '/staking-pools',
+    STAKING_EPOCHS: '/staking-epochs',
+    STAKING_POOL_EPOCHS: '/staking-pool-epochs',
+    STAKING_DELEGATOR: '/staking-delegator',
+    STAKING_DELEGATOR_EPOCHS: '/staking-delegator-epochs',
+    STAKING_EVENTS: '/staking-events',
+    TRADING_PAIRS: '/trading-pairs',
+    NEXT_STAKING_POOL_EPOCH: '/staking-pool-next-epoch',
+    RECOMMEND_STAKING_POOL: '/recommend-staking-pool',
+};
+
+export const stakingClient = {
+    // if no delegatorAddress is passed, returns all staking pool staked in 0x contracts
+    async getStakingPoolsAsync(delegatorAddress?: string): Promise<StakingPoolStats[]> {
+        return [];
+    },
+    /**
+     * this hits the server 3 times
+     * 1. Get StakingPoolStats for specified poolId from /staking-pools
+     * 2. Get all epoch data from /staking-pool-epochs
+     * 3. Get all neccessary metadata related to trading pairs from /trading-pairs
+     */
+    async getDetailedStakingPoolStatsAsync(poolId: string): Promise<DetailedStakingPoolStats> {
+        return {};
+    },
+    /**
+     * Gets aggregate statistics of the 0x staking system
+     */
+    async getStakingStatsAsync(): Promise<StakingStats> {
+        return {};
+    },
+    /**
+     * Gets delegator staking information and StakingPoolStats related to staked pools
+     */
+    async getStakingDelegatorStatsAsync(delegatorAddress?: string): Promise<StakingDelegatorStats> {
+        return {};
+    },
+    /**
+     * Recommends staking pools for the amount of zrxStateAmount given
+     */
+    async getRecommendedStakingPoolAsync(delegatorAddress: string, zrxStakeAmount: BigNumber): Promise<StakingPoolStats[]> {
+        return {};
+    },
+    /**
+     * TODO(dave4506) add event types
+     */
+    async getStakingDelegatorActivityAsync(delegatorAddress: string): Promise<any> {
+        return {};
+    },
+    /**
+     * TODO(dave4506) add event types
+     */
+    async getStakingPoolActivityAsync(poolId: string): Promise<any> {
+        return {};
+    },
+    /**
+     * TODO(dave4506) add event types
+     */
+    async getStakingActivityAsync(): Promise<any> {
+        return {};
+    },
+};

--- a/ts/staking_client.ts
+++ b/ts/staking_client.ts
@@ -1,7 +1,15 @@
 import { BigNumber } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { DetailedStakingPoolStats, StakingDelegatorStats, StakingPoolStats, StakingStats } from './staking_types';
+import {
+    DetailedStakingPoolStats,
+    StakingDelegatorRelevantEvents,
+    StakingDelegatorStats,
+    StakingPoolRelevantEvents,
+    StakingPoolStats,
+    StakingRelevantEvents,
+    StakingStats,
+} from './staking_types';
 
 const STANDARD_STAKING_API_ENDPOINTS = {
     STAKING: '/staking',
@@ -22,7 +30,7 @@ export const stakingClient = {
         return [];
     },
     /**
-     * this hits the server 3 times
+     * This hits the server 3 times
      * 1. Get StakingPoolStats for specified poolId from /staking-pools
      * 2. Get all epoch data from /staking-pool-epochs
      * 3. Get all neccessary metadata related to trading pairs from /trading-pairs
@@ -51,19 +59,19 @@ export const stakingClient = {
     /**
      * TODO(dave4506) add event types
      */
-    async getStakingDelegatorActivityAsync(delegatorAddress: string): Promise<any> {
+    async getStakingDelegatorActivityAsync(delegatorAddress: string): Promise<StakingDelegatorRelevantEvents[]> {
         return {};
     },
     /**
      * TODO(dave4506) add event types
      */
-    async getStakingPoolActivityAsync(poolId: string): Promise<any> {
+    async getStakingPoolActivityAsync(poolId: string): Promise<StakingPoolRelevantEvents[]> {
         return {};
     },
     /**
      * TODO(dave4506) add event types
      */
-    async getStakingActivityAsync(): Promise<any> {
+    async getStakingActivityAsync(): Promise<StakingRelevantEvents[]> {
         return {};
     },
 };

--- a/ts/staking_types.ts
+++ b/ts/staking_types.ts
@@ -141,3 +141,29 @@ export interface TradingPairMetadata {
 }
 
 // TODO(dave4506) Add activity types
+enum StakingEventType {
+    StakingContract = 'STAKING',
+    StakingStaker = 'STAKING_STAKER',
+    StakingPool = 'STAKING_POOL',
+    StakingDelegator = 'STAKING_DELEGATOR',
+}
+
+export type StakingDelegatorRelevantEvents = StakingPoolRelevantEvents | StakingStakerEvent | StakingDelegatorEvent;
+export type StakingPoolRelevantEvents = StakingContractEvent | StakingRelevantEvents;
+export type StakingRelevantEvents =  StakingPoolEvent;
+
+export interface StakingContractEvent {
+    eventType: StakingEventType.StakingContract;
+}
+
+export interface StakingStakerEvent {
+    eventType: StakingEventType.StakingStaker;
+}
+
+export interface StakingPoolEvent {
+    eventType: StakingEventType.StakingPool;
+}
+
+export interface StakingDelegatorEvent {
+    eventType: StakingEventType.StakingDelegator;
+}

--- a/ts/staking_types.ts
+++ b/ts/staking_types.ts
@@ -1,0 +1,143 @@
+import { BigNumber } from '@0x/utils';
+
+export interface EpochTime {
+    observedTimestamp: number;
+    txHash: string;
+    blockNumber: number;
+}
+
+export interface ApproximateEpochTime {
+    approximateTimestamp: number;
+    blockNumber: number;
+}
+
+export interface EpochStats {
+    epoch_id: number;
+    startingEpochTime: EpochTime;
+    endingEpochTime?: EpochTime;
+}
+
+export interface EpochStakingStats extends EpochStats {
+    totalFeesGeneratedInEth: BigNumber;
+    totalFeesSharedToZrxDelegatorsInEth: BigNumber;
+    totalTakerFills: TotalTakerFills;
+    totalZrxStaked: BigNumber;
+}
+
+export interface EpochStakingStakingPoolDelegatorStats {
+    delegatorAddress: string;
+    stakingPoolOwnershipShare: BigNumber;
+    totalFeesSharedInEth: BigNumber;
+    totalZrxStaked: BigNumber;
+}
+
+export interface EpochStakingPoolStats extends EpochStakingStats {
+    totalFeesSharedToZrxDelegatorsInEth: BigNumber;
+    operatorOwnershipShare: BigNumber;
+    delegators: EpochStakingStakingPoolDelegatorStats[];
+}
+
+export interface EpochStakingDelegatorPoolStats {
+    poolId: number;
+    stakingPoolOwnershipShare: BigNumber;
+    totalFeesSharedInEth: BigNumber;
+    totalZrxStaked: BigNumber;
+}
+
+export interface StakingDelegatorStats {
+    delegatorAddress: string;
+    currentEpoch: EpochStakingDelegatorStats;
+    historical: HistoricalStakingDelegatorStats;
+}
+
+export interface EpochStakingDelegatorStats extends EpochStats {
+    totalZrxStaked: BigNumber;
+    stakeStatus: ZrxStakingStatus;
+    totalFeesSharedInEth: BigNumber;
+    stakedPools: EpochStakingDelegatorPoolStats[];
+}
+
+export interface HistoricalStakingStats {
+    totalFeesGeneratedInEth: BigNumber;
+    totalFeesSharedToZrxDelegatorsInEth: BigNumber;
+    totalTakerFills: TotalTakerFills;
+}
+
+export interface HistoricalStakingDelegatorStats {
+    totalFeesSharedInEth: number;
+}
+
+export interface TakerFills {
+    makerAssetData: string;
+    takerAssetData: string;
+    fillsInTakerUnit: BigNumber;
+    fillsInUsd: BigNumber;
+    fillsInEth: BigNumber;
+}
+
+export interface TotalTakerFills {
+    totalInUsd: BigNumber;
+    totalInEth: BigNumber;
+    totalPerTradingPairs: TakerFills[];
+}
+
+export interface StakingStats {
+    stakingContractProxyAddress: string;
+    currentEpoch: EpochStakingStats;
+    historical: HistoricalStakingStats;
+}
+
+export enum StakingPoolStatus {
+    Active = 'ACTIVE', Inactive = 'INACTIVE',
+}
+
+export interface NextEpochStakingPoolStats {
+    approximateStakeRatio: number;
+    startingEpoch: ApproximateEpochTime;
+}
+
+export interface StakingPoolMetadata {
+    logoUrl?: string;
+    location?: string;
+    bio?: string;
+    websiteUrl?: string;
+    name?: string;
+}
+
+export interface ZrxStakingStatus {
+    inactive: BigNumber;
+    active: BigNumber;
+    delegated: BigNumber;
+    withdrawable: BigNumber;
+}
+
+export interface StakingPoolStats {
+    poolId: number;
+    operatorAddress: string;
+    makerAddresses: string[];
+    verified: boolean;
+    status: StakingPoolStatus;
+    metadata: StakingPoolMetadata;
+    nextEpoch: NextEpochStakingPoolStats;
+    currentEpoch: EpochStakingPoolStats;
+    historical: HistoricalStakingStats;
+}
+
+export interface DetailedStakingPoolStats extends StakingPoolStats {
+    allEpochs: EpochStakingPoolStats[];
+    relevantTradingPairMetadata: TradingPairMetadata[];
+}
+
+export interface AssetMetadata {
+    assetData: string;
+    themeColorInHex: string;
+    logoUrl: string;
+    ticker: string;
+}
+
+export interface TradingPairMetadata {
+    makerAsset: AssetMetadata;
+    takerAsset: AssetMetadata;
+}
+
+// TODO(dave4506) Add activity types

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -712,42 +712,11 @@ export interface WebsiteBackendJobInfo {
     url: string;
 }
 
-export interface WebsiteBackendCurrency {
-    name: string;
-    iconUrl: string;
-}
-
-export interface WebsiteBackendTradingPair {
-    id: string;
-    price: string;
-    currency: string;
-    firstCurrency: WebsiteBackendCurrency;
-    secondCurrency: WebsiteBackendCurrency;
-    // Is there a link to a trading pair detail url?
-    url: string;
-}
-
-export interface WebsiteBackendTradingPairs {
-    tradingPairs: WebsiteBackendTradingPair[];
-}
-
 export interface StakingPoolMetrics {
     totalVolume: string;
     totalStaked: string;
     feesGenerated: string;
     rewardsShared: string;
-}
-
-export interface WebsiteBackendStakingPoolInfo {
-    // 0x1234...1234 <= is this the id?
-    id: string;
-    website: string;
-    rewardsShared: number;
-    iconUrl: string;
-    estimatedStake: number;
-    nextEpoch: string;
-    currentEpochMetrics: StakingPoolMetrics;
-    allTimeMetrics: StakingPoolMetrics;
 }
 
 export interface StakingHistoryDataset {

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -121,6 +121,7 @@ export const constants = {
     URL_VOTE_FAQ:
         'https://blog.0xproject.com/vote-with-zrx-to-add-support-for-erc-1155-and-the-staticcallassetproxy-49a855807bcd#967f',
     URL_ZEIP_REPO: 'https://github.com/0xProject/ZEIPs/',
+    URL_SSA: 'INSERT_URL_HERE', // This will be the endpoint for a standard staking api url
     TYPES_SECTION_NAME: 'types',
     EXTERNAL_EXPORTS_SECTION_NAME: 'external exports',
     TYPE_TO_SYNTAX: {


### PR DESCRIPTION
This PR adds types as specified by our spec for the Staking API. Keep in mind that this is still subject to change (albeit changes shouldn't be large). Hopefully with these types, as the front end components get built out we can use some of the diction that the staking API uses for props and etc.

To clarify a few things per the API: 

- The 'time' unit used through the staking API is referred as an 'epoch'. 
- For graph visualizations throughout the user experience, you would need to fetch all the 'epochs' from endpoints like: `/staking-pool-epochs`.
- The `stakingDelegator` refers to the account user. 

TODO
- [x] Add event/activity types
- [ ] Add mockup data?