### PR TITLE
Account view additional components, style tweaks

### DIFF
--- a/ts/components/button.tsx
+++ b/ts/components/button.tsx
@@ -1,3 +1,4 @@
+import { darken } from 'polished';
 import * as React from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import styled from 'styled-components';
@@ -111,7 +112,7 @@ const ButtonBase = styled.button<ButtonInterface>`
     }
 
     &:hover {
-        background-color: ${props => !props.isTransparent && !props.isWithArrow && '#04BEA8'};
+        background-color: ${props => !props.isTransparent && !props.isWithArrow && (darken(0.05, props.bgColor || colors.brandLight))};
         border-color: ${props => props.isTransparent && !props.isNoBorder && !props.isWithArrow && '#00AE99'};
 
         svg {

--- a/ts/components/button.tsx
+++ b/ts/components/button.tsx
@@ -58,7 +58,7 @@ export const Button: React.StatelessComponent<ButtonInterface> = (props: ButtonI
             {children}
 
             {isWithArrow && (
-                <svg width="16" height="15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <svg viewBox="0 0 16 15" width="16" height="15" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M4.484.246l.024 1.411 8.146.053L.817 13.547l.996.996L13.65 2.706l.052 8.146 1.412.024L15.045.315 4.484.246z" />
                 </svg>
             )}

--- a/ts/components/modals/button_close.tsx
+++ b/ts/components/modals/button_close.tsx
@@ -37,4 +37,8 @@ const StyledButtonClose = styled.button.attrs({
         visibility: hidden;
         position: absolute;
     }
+
+    path {
+        fill: ${props => props.theme.textColor};
+    }
 `;

--- a/ts/components/modals/input.tsx
+++ b/ts/components/modals/input.tsx
@@ -20,6 +20,7 @@ interface InputProps {
     errors?: ErrorProps;
     isErrors?: boolean;
     required?: boolean;
+    placeholder?: string;
     onChange?: (e: React.ChangeEvent) => void;
 }
 
@@ -67,7 +68,7 @@ export const CheckBoxInput = (props: CheckBoxProps) => {
 };
 
 export const Input = React.forwardRef((props: InputProps, ref?: React.Ref<HTMLInputElement>) => {
-    const { name, label, type, errors, defaultValue, onChange, width, className } = props;
+    const { name, label, type, errors, defaultValue, onChange, width, className, placeholder } = props;
     const id = `input-${name}`;
     const componentType = type === 'textarea' ? 'textarea' : 'input';
     const isErrors = errors.hasOwnProperty(name) && errors[name] !== null;
@@ -84,6 +85,7 @@ export const Input = React.forwardRef((props: InputProps, ref?: React.Ref<HTMLIn
                 isErrors={isErrors}
                 defaultValue={defaultValue}
                 onChange={onChange}
+                placeholder={placeholder}
                 {...inputProps}
             />
             {isErrors && <Error>{errorMessage}</Error>}

--- a/ts/components/text.tsx
+++ b/ts/components/text.tsx
@@ -20,6 +20,7 @@ interface HeadingProps extends BaseTextInterface {
     marginBottom?: string;
     color?: string;
     children?: React.ReactNode | string;
+    style?: object;
 }
 
 interface ParagraphProps extends BaseTextInterface {

--- a/ts/components/ui/circle_check_mark.tsx
+++ b/ts/components/ui/circle_check_mark.tsx
@@ -4,9 +4,10 @@ interface ICircleCheckMarkProps {
     color?: string;
     width?: string;
     height?: string;
+    fill?: string;
 }
 
-export const CircleCheckMark: React.FC<ICircleCheckMarkProps> = ({ color, width, height }) => (
+export const CircleCheckMark: React.FC<ICircleCheckMarkProps> = ({ color, width, height, fill }) => (
     <svg
         style={{ width, height }}
         width="24"
@@ -18,6 +19,7 @@ export const CircleCheckMark: React.FC<ICircleCheckMarkProps> = ({ color, width,
         <path
             d="M12 23.25C18.2132 23.25 23.25 18.2132 23.25 12C23.25 5.7868 18.2132 0.75 12 0.75C5.7868 0.75 0.75 5.7868 0.75 12C0.75 18.2132 5.7868 23.25 12 23.25Z"
             stroke={color}
+            fill={fill}
             strokeMiterlimit="10"
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/ts/components/ui/panel_header.tsx
+++ b/ts/components/ui/panel_header.tsx
@@ -49,17 +49,26 @@ const Avatar = styled.figure<AvatarProps>`
         object-fit: cover;
     }
 
-    svg {
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        transform: translateX(50%) translateY(50%);
-    }
-
     @media (max-width: 768px) {
         width: 32px;
         height: 32px;
         display: ${props => !props.isResponsive && 'none'};
+    }
+`;
+
+const IconWrap = styled.div`
+    padding: 5px;
+    border-radius: 50%;
+    border: 1px solid ${colors.border};
+    position: relative;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    transform: translateX(50%) translateY(50%);
+    background-color: ${colors.white};
+
+    svg {
+        display: block;
     }
 `;
 
@@ -77,14 +86,18 @@ export const PanelHeader: React.StatelessComponent<PanelHeaderProps> = ({
                     <img src={avatarSrc} />
 
                     {icon === 'check' &&
-                        <CircleCheckMark fill="#fff" />
+                        <IconWrap>
+                            <CircleCheckMark fill="#fff" />
+                        </IconWrap>
                     }
 
                     {icon === 'clock' &&
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <path fill="#fff" d="M12 23.5C5.64614 23.5 0.5 18.3539 0.5 12C0.5 5.64614 5.64614 0.5 12 0.5C18.3539 0.5 23.5 5.64614 23.5 12C23.5 18.3539 18.3539 23.5 12 23.5Z" stroke="black"/>
-                            <path d="M11.0762 4.61523V12.6081L18.4608 17.5383" stroke="black"/>
-                        </svg>
+                        <IconWrap>
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path fill="#fff" d="M12 23.5C5.64614 23.5 0.5 18.3539 0.5 12C0.5 5.64614 5.64614 0.5 12 0.5C18.3539 0.5 23.5 5.64614 23.5 12C23.5 18.3539 18.3539 23.5 12 23.5Z" stroke="black"/>
+                                <path d="M11.0762 4.61523V12.6081L18.4608 17.5383" stroke="black"/>
+                            </svg>
+                        </IconWrap>
                     }
                 </Avatar>
             )}

--- a/ts/components/ui/panel_header.tsx
+++ b/ts/components/ui/panel_header.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import { Heading, Paragraph } from 'ts/components/text';
 import { colors } from 'ts/style/colors';
 
+import { CircleCheckMark } from 'ts/components/ui/circle_check_mark';
+
 interface PanelHeaderProps {
     avatarSrc?: string;
     avatarComponent?: React.ReactNode;
@@ -27,6 +29,11 @@ const Wrap = styled.div`
             display: none;
         }
     }
+`;
+
+const Flex = styled.div`
+    display: flex;
+    align-items: center;
 `;
 
 const Avatar = styled.figure<AvatarProps>`
@@ -62,13 +69,17 @@ export const PanelHeader: React.StatelessComponent<PanelHeaderProps> = ({
             )}
 
             <div>
-                <Heading
-                    size="small"
-                    fontWeight="500"
-                    isNoMargin={true}
-                >
-                    {title}
-                </Heading>
+                <Flex>
+                    <Heading
+                        size="small"
+                        fontWeight="500"
+                        isNoMargin={true}
+                        style={{ marginRight: '8px' }}
+                    >
+                        {title}
+                    </Heading>
+                    <CircleCheckMark />
+                </Flex>
 
                 <Paragraph
                     fontSize="17px"

--- a/ts/components/ui/panel_header.tsx
+++ b/ts/components/ui/panel_header.tsx
@@ -42,7 +42,7 @@ const Avatar = styled.figure<AvatarProps>`
     height: 80px;
     background-color: #fff;
     border: 1px solid ${colors.border};
-    margin-right: 30px;
+    margin-right: 20px;
     position: relative;
 
     img {

--- a/ts/components/ui/panel_header.tsx
+++ b/ts/components/ui/panel_header.tsx
@@ -12,6 +12,7 @@ interface PanelHeaderProps {
     title: string | React.ReactNode;
     subtitle: string;
     isResponsiveAvatar?: boolean;
+    icon?: string;
 }
 
 interface AvatarProps {
@@ -42,9 +43,17 @@ const Avatar = styled.figure<AvatarProps>`
     background-color: #fff;
     border: 1px solid ${colors.border};
     margin-right: 30px;
+    position: relative;
 
     img {
         object-fit: cover;
+    }
+
+    svg {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        transform: translateX(50%) translateY(50%);
     }
 
     @media (max-width: 768px) {
@@ -59,12 +68,24 @@ export const PanelHeader: React.StatelessComponent<PanelHeaderProps> = ({
     title,
     subtitle,
     isResponsiveAvatar,
+    icon,
 }) => {
     return (
         <Wrap>
             {avatarSrc && (
                 <Avatar isResponsive={isResponsiveAvatar}>
                     <img src={avatarSrc} />
+
+                    {icon === 'check' &&
+                        <CircleCheckMark fill="#fff" />
+                    }
+
+                    {icon === 'clock' &&
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path fill="#fff" d="M12 23.5C5.64614 23.5 0.5 18.3539 0.5 12C0.5 5.64614 5.64614 0.5 12 0.5C18.3539 0.5 23.5 5.64614 23.5 12C23.5 18.3539 18.3539 23.5 12 23.5Z" stroke="black"/>
+                            <path d="M11.0762 4.61523V12.6081L18.4608 17.5383" stroke="black"/>
+                        </svg>
+                    }
                 </Avatar>
             )}
 
@@ -78,7 +99,6 @@ export const PanelHeader: React.StatelessComponent<PanelHeaderProps> = ({
                     >
                         {title}
                     </Heading>
-                    <CircleCheckMark />
                 </Flex>
 
                 <Paragraph

--- a/ts/icons/illustrations/revenue.svg
+++ b/ts/icons/illustrations/revenue.svg
@@ -1,0 +1,10 @@
+<svg width="142" height="142" viewBox="0 0 142 142" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="142" height="142">
+<circle cx="71" cy="71" r="70" fill="#00AE99" stroke="#00AE99" stroke-width="2"/>
+</mask>
+<g mask="url(#mask0)">
+<circle cx="71" cy="71" r="70" stroke="#00AE99" stroke-width="2"/>
+<path d="M114.959 17.7988H42.1595M114.959 17.7988V89.7588M114.959 17.7988L1.55945 131.199M42.1595 17.7988L60.3595 35.9988M42.1595 17.7988V53.6388M60.3595 35.9988L-13.5605 109.919M60.3595 35.9988V155.279M114.959 89.7588L97.5995 72.3988M114.959 89.7588V131.199M97.5995 72.3988L25.9195 155.279M97.5995 72.3988V142.399" stroke="#00AE99" stroke-width="2"/>
+<path d="M77.7197 95.6406V157.521" stroke="#00AE99" stroke-width="2"/>
+</g>
+</svg>

--- a/ts/pages/account/account_activity_summary.tsx
+++ b/ts/pages/account/account_activity_summary.tsx
@@ -10,6 +10,7 @@ interface AccountActivitySummaryProps {
     subtitle: string;
     avatarSrc?: string;
     children?: any;
+    icon?: string;
 }
 
 const Wrap = styled.div`
@@ -45,6 +46,7 @@ export const AccountActivitySummary: React.StatelessComponent<AccountActivitySum
     title,
     subtitle,
     avatarSrc,
+    icon,
     children,
 }) => {
     return (
@@ -53,6 +55,7 @@ export const AccountActivitySummary: React.StatelessComponent<AccountActivitySum
                 title={title}
                 subtitle={subtitle}
                 avatarSrc={avatarSrc}
+                icon={icon}
             />
 
             <ChildWrap>

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { DialogContent, DialogOverlay } from '@reach/dialog';
+
+import { ButtonClose } from 'ts/components/modals/button_close';
+import { Heading, Paragraph } from 'ts/components/text';
+
+import { colors } from 'ts/style/colors';
+
+interface Props {
+  isOpen?: boolean;
+  onDismiss?: () => void;
+}
+
+export const AccountApplyModal: React.FunctionComponent<Props> = ({
+  isOpen,
+  onDismiss,
+}) => {
+  return (
+    <DialogOverlay
+        style={{ background: 'rgba(255, 255, 255, 0.8)', zIndex: 30 }}
+        isOpen={isOpen}
+        onDismiss={onDismiss}
+    >
+      <StyledDialogContent>
+        <Heading
+          asElement="h3"
+          fontWeight="400"
+          marginBottom="20px"
+        >
+          Apply for staking node
+        </Heading>
+
+        <Paragraph isMuted={true} color={colors.textDarkPrimary}>
+            Your vote will help to decide the future of the protocol. You will be receiving a custom
+            “I voted” NFT as a token of our appreciation.
+        </Paragraph>
+
+        <ButtonClose onClick={onDismiss} />
+      </StyledDialogContent>
+    </DialogOverlay>
+  )
+}
+
+const StyledDialogContent = styled(DialogContent)`
+    position: relative;
+    max-width: 800px;
+    background-color: #f6f6f6 !important;
+    padding: 60px 60px !important;
+
+    @media (max-width: 768px) {
+        width: calc(100vw - 40px) !important;
+        margin: 40px auto !important;
+        padding: 30px 30px !important;
+    }
+`;

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -14,11 +14,15 @@ interface Props {
   onDismiss?: () => void;
 }
 
+interface FormProps {
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void,
+}
+
 export const AccountApplyModal: React.FunctionComponent<Props> = ({
   isOpen,
   onDismiss,
 }) => {
-  const onSubmit = (event: React.FormEvent<HTMLInputElement>): void => {
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     alert('submit!');
   };
@@ -84,7 +88,7 @@ const StyledDialogContent = styled(DialogContent)`
     }
 `;
 
-const InputWrap = styled.form`
+const InputWrap = styled.form<FormProps>`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -64,7 +64,7 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
               Back
             </ButtonBack>
 
-            <Button type="submit">
+            <Button type="submit" color={colors.white}>
               Submit
             </Button>
           </footer>

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -18,8 +18,8 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
   isOpen,
   onDismiss,
 }) => {
-  const onSubmit = (e: React.FormEvent<HTMLInputElement>): void => {
-    e.preventDefault();
+  const onSubmit = (event: React.FormEvent<HTMLInputElement>): void => {
+    event.preventDefault();
     alert('submit!');
   };
   

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
+
 import { DialogContent, DialogOverlay } from '@reach/dialog';
 
 import { Button } from 'ts/components/button';
@@ -15,7 +16,7 @@ interface Props {
 }
 
 interface FormProps {
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void,
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
 }
 
 export const AccountApplyModal: React.FunctionComponent<Props> = ({
@@ -26,7 +27,7 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
     event.preventDefault();
     alert('submit!');
   };
-  
+
   return (
     <DialogOverlay
         style={{ background: 'rgba(255, 255, 255, 0.8)', zIndex: 30 }}
@@ -46,7 +47,7 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
             Your vote will help to decide the future of the protocol. You will be receiving a custom
           “I voted” NFT as a token of our appreciation.
         </Paragraph>
-        
+
         <InputWrap onSubmit={onSubmit}>
           <Input width="half" label="Your name" />
           <Input width="half" label="Your email" />
@@ -62,7 +63,7 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
 
               Back
             </ButtonBack>
-            
+
             <Button type="submit">
               Submit
             </Button>
@@ -72,8 +73,8 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
         <ButtonClose onClick={onDismiss} />
       </StyledDialogContent>
     </DialogOverlay>
-  )
-}
+  );
+};
 
 const StyledDialogContent = styled(DialogContent)`
     position: relative;
@@ -119,3 +120,4 @@ const ButtonBack = styled.button`
 
   cursor: pointer;
 `;
+

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { DialogContent, DialogOverlay } from '@reach/dialog';
 
+import { Button } from 'ts/components/button';
 import { ButtonClose } from 'ts/components/modals/button_close';
+import { Input } from 'ts/components/modals/input';
 import { Heading, Paragraph } from 'ts/components/text';
 
 import { colors } from 'ts/style/colors';
@@ -16,6 +18,11 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
   isOpen,
   onDismiss,
 }) => {
+  const onSubmit = e => {
+    e.preventDefault();
+    alert('submit!');
+  };
+  
   return (
     <DialogOverlay
         style={{ background: 'rgba(255, 255, 255, 0.8)', zIndex: 30 }}
@@ -33,8 +40,30 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
 
         <Paragraph isMuted={true} color={colors.textDarkPrimary}>
             Your vote will help to decide the future of the protocol. You will be receiving a custom
-            “I voted” NFT as a token of our appreciation.
+          “I voted” NFT as a token of our appreciation.
         </Paragraph>
+        
+        <InputWrap onSubmit={onSubmit}>
+          <Input width="half" label="Your name" />
+          <Input width="half" label="Your email" />
+          <Input width="full" label="Name of your project/company" />
+          <Input width="full" label="Do you have any documentation or a website?" placeholder="example.com" type="url" />
+          <Input width="full" label="Anything else?" type="textarea" />
+
+          <footer>
+            <ButtonBack onClick={onDismiss}>
+              <svg width="20" height="16" viewBox="0 0 20 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M7.41917 15.6953L8.40025 14.6807L2.67727 8.88297L19.417 8.88297L19.417 7.47494L2.67727 7.47494L8.40025 1.6772L7.41917 0.662593L-0.000271501 8.17895L7.41917 15.6953Z" fill="#5C5C5C"/>
+              </svg>
+
+              Back
+            </ButtonBack>
+            
+            <Button type="submit">
+              Submit
+            </Button>
+          </footer>
+        </InputWrap>
 
         <ButtonClose onClick={onDismiss} />
       </StyledDialogContent>
@@ -53,4 +82,36 @@ const StyledDialogContent = styled(DialogContent)`
         margin: 40px auto !important;
         padding: 30px 30px !important;
     }
+`;
+
+const InputWrap = styled.form`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  > div {
+    margin-bottom: 30px;
+  }
+
+  footer {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
+`;
+
+const ButtonBack = styled.button`
+  appearance: none;
+  background: none;
+  border: 0;
+  font: inherit;
+  color: ${colors.textDarkSecondary};
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin-right: 15px;
+  }
+
+  cursor: pointer;
 `;

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -120,4 +120,3 @@ const ButtonBack = styled.button`
 
   cursor: pointer;
 `;
-

--- a/ts/pages/account/account_apply_modal.tsx
+++ b/ts/pages/account/account_apply_modal.tsx
@@ -18,7 +18,7 @@ export const AccountApplyModal: React.FunctionComponent<Props> = ({
   isOpen,
   onDismiss,
 }) => {
-  const onSubmit = e => {
+  const onSubmit = (e: React.FormEvent<HTMLInputElement>): void => {
     e.preventDefault();
     alert('submit!');
   };

--- a/ts/pages/account/account_figure.tsx
+++ b/ts/pages/account/account_figure.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+interface AccountFigureProps {
+    label: string;
+    headerComponent?: () => React.ReactNode;
+    children: React.ReactNode;
+}
+
+export const AccountFigure: React.FC<AccountFigureProps> = ({
+    label,
+    headerComponent,
+    children,
+}) => {
+    return (
+        <FigureItem>
+            <header>
+                {label}
+                {headerComponent()}
+            </header>
+
+            {children}
+        </FigureItem>
+    );
+};
+
+const FigureItem = styled.div`
+    background-color: #fff;
+    padding: 20px;
+    width: 252px;
+    height: 94px;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    font-size: 20px;
+
+    header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 17px;
+        color: #999;
+        font-weight: 200;
+    }
+
+    button {
+        border: 0;
+        font-size: 17px;
+        font-weight: 200;
+
+        svg {
+            height: 13px;
+        }
+    }
+
+    @media (min-width: 768px) {
+        & + & {
+            margin-left: 12px;
+        }
+    }
+
+    @media (max-width: 768px) {
+        width: 100%;
+    }
+`;

--- a/ts/pages/account/account_stake_overview.tsx
+++ b/ts/pages/account/account_stake_overview.tsx
@@ -128,8 +128,15 @@ export const AccountStakeOverview: React.StatelessComponent<StakeOverviewProps> 
             </Flex>
 
             <MobileActions>
-                <Button color="#fff">
-                    View history
+                <Button
+                    to="/account/history"
+                    color={colors.white}
+                    fontSize="17px"
+                    fontWeight="300"
+                    padding="15px 35px"
+                    isFullWidth={true}
+                >
+                    View History
                 </Button>
 
                 <Button
@@ -240,8 +247,9 @@ const MobileActions = styled.div`
         width: 100%;
     }
 
-    button + button {
-        margin-top: 20px;
+    a + button,
+    a + a {
+        margin-top: 16px;
     }
 
     @media (min-width: 768px) {

--- a/ts/pages/account/account_stake_overview.tsx
+++ b/ts/pages/account/account_stake_overview.tsx
@@ -186,7 +186,7 @@ const Action = styled(FlexBase)`
             padding-left: 30px;
         }
 
-        button {
+        button, a {
             display: none;
         }
     }

--- a/ts/pages/account/account_stake_overview.tsx
+++ b/ts/pages/account/account_stake_overview.tsx
@@ -75,7 +75,17 @@ export const AccountStakeOverview: React.StatelessComponent<StakeOverviewProps> 
                         </div>
                     </InlineStats>
 
-                    <Button color="red" bgColor="#fff" borderColor={colors.border}>
+                    <Button
+                        to="/"
+                        color={colors.red}
+                        borderColor="#D5D5D5"
+                        bgColor={colors.white}
+                        isTransparent={true}
+                        fontSize="17px"
+                        fontWeight="300"
+                        isNoBorder={true}
+                        padding="15px 35px"
+                    >
                         Remove
                     </Button>
                 </Action>
@@ -105,8 +115,14 @@ export const AccountStakeOverview: React.StatelessComponent<StakeOverviewProps> 
                         </div>
                     </InlineStats>
 
-                    <Button color="#fff" to="/account/history">
-                        View history
+                    <Button
+                        to="/account/history"
+                        color={colors.white}
+                        fontSize="17px"
+                        fontWeight="300"
+                        padding="15px 35px"
+                    >
+                        View History
                     </Button>
                 </Action>
             </Flex>
@@ -116,7 +132,18 @@ export const AccountStakeOverview: React.StatelessComponent<StakeOverviewProps> 
                     View history
                 </Button>
 
-                <Button color="red" bgColor="#fff" borderColor={colors.border}>
+                <Button
+                    to="/"
+                    color={colors.red}
+                    borderColor="#D5D5D5"
+                    bgColor={colors.white}
+                    isTransparent={true}
+                    fontSize="17px"
+                    fontWeight="300"
+                    isNoBorder={true}
+                    padding="15px 35px"
+                    isFullWidth={true}
+                >
                     Remove
                 </Button>
             </MobileActions>
@@ -172,6 +199,7 @@ const Action = styled(FlexBase)`
 
     > div {
         font-size: 18px;
+        flex-shrink: 0;
     }
 
     @media (min-width: 768px) {

--- a/ts/pages/account/account_vote.tsx
+++ b/ts/pages/account/account_vote.tsx
@@ -71,7 +71,7 @@ export const AccountVote: React.StatelessComponent<AccountVoteProps> = ({
                         d="M5.50551 6.99961L0 12.5051L0.989949 13.4951L6.49546 7.98956L12.001 13.4951L12.9909 12.5051L7.48541 6.99961L12.99 1.49508L12 0.505127L6.49546 6.00966L0.990926 0.505127L0.0009767 1.49508L5.50551 6.99961Z"
                         fill="#E71D36"
                     />
-                </svg> 
+                </svg>
              )}
 
              Voted {vote}

--- a/ts/pages/account/account_vote.tsx
+++ b/ts/pages/account/account_vote.tsx
@@ -37,11 +37,17 @@ const Wrap = styled.div`
     }
 `;
 
-const Status = styled.p<StatusProps>`
+const Status = styled.div<StatusProps>`
     font-size: 20px;
     color: ${props => props.color};
     text-transform: capitalize;
     margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+
+    svg {
+        margin-right: 8px;
+    }
 `;
 
 export const AccountVote: React.StatelessComponent<AccountVoteProps> = ({
@@ -52,8 +58,23 @@ export const AccountVote: React.StatelessComponent<AccountVoteProps> = ({
 }) => {
  return (
     <Wrap>
-        <Status color={vote === 'yes' ? '#00AE99' : '#E71D36'}>
-            Voted {vote}
+         <Status color={vote === 'yes' ? colors.brandLight : '#E71D36'}>
+             {vote === 'yes' ? (
+                <svg width={14} viewBox="0 0 18 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17 1L6 12L1 7" stroke={colors.brandLight} strokeWidth="1.4" />
+                </svg>
+                ) : (
+                <svg width={14} viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M5.50551 6.99961L0 12.5051L0.989949 13.4951L6.49546 7.98956L12.001 13.4951L12.9909 12.5051L7.48541 6.99961L12.99 1.49508L12 0.505127L6.49546 6.00966L0.990926 0.505127L0.0009767 1.49508L5.50551 6.99961Z"
+                        fill="#E71D36"
+                    />
+                </svg> 
+             )}
+
+             Voted {vote}
         </Status>
 
         <Heading

--- a/ts/pages/account/activity.tsx
+++ b/ts/pages/account/activity.tsx
@@ -140,4 +140,10 @@ const ContentWrap = styled.div`
     width: calc(100% - 40px);
     max-width: 1152px;
     margin: 90px auto 0 auto;
+
+    @media (max-width: 768px) {
+        h1 {
+            font-size: 34px;
+        }
+    }
 `;

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -23,6 +23,7 @@ const MOCK_DATA = {
         title: '500 ZRX will be removed from Binance Pool in 10 days',
         subtitle: 'Your tokens will need to be manually withdrawn once they are removed ',
         avatarSrc: 'https://static.cryptotips.eu/wp-content/uploads/2019/05/binance-bnb-logo.png',
+        icon: 'clock',
     },
     stakes: [
         {
@@ -166,6 +167,7 @@ export const Account: React.FC<AccountProps> = () => {
                     title={MOCK_DATA.activitySummary.title}
                     subtitle={MOCK_DATA.activitySummary.subtitle}
                     avatarSrc={MOCK_DATA.activitySummary.avatarSrc}
+                    icon={MOCK_DATA.activitySummary.icon}
                 >
                     <StatFigure
                         label="Withdraw date"
@@ -177,6 +179,7 @@ export const Account: React.FC<AccountProps> = () => {
                     title="Your ZRX is unlocked and ready for withdrawal"
                     subtitle="6,000 ZRX  →  0x12345...12345"
                     avatarSrc={MOCK_DATA.activitySummary.avatarSrc}
+                    icon="check"
                 >
                     <Button
                         to="/"

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -347,6 +347,16 @@ const SectionHeader = styled.header`
     justify-content: space-between;
     align-items: center;
     margin-bottom: 30px;
+
+    @media (max-width: 768px) {
+        h3 {
+            font-size: 28px;
+        }
+
+        a, button {
+            display: none;
+        }
+    }
 `;
 
 const Grid = styled.div`

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -262,7 +262,8 @@ export const Account: React.FC<AccountProps> = () => {
 
             <AccountApplyModal
                 isOpen={isApplyModalOpen}
-                onDismiss={() => toggleApplyModal(false)} />
+                onDismiss={() => toggleApplyModal(false)}
+            />
         </StakingPageLayout>
     );
 };

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -81,7 +81,6 @@ export const Account: React.FC<AccountProps> = () => {
         <StakingPageLayout title="0x Staking | Account">
             <HeaderWrapper>
                 <Inner>
-                    {/* Note: shared component in MarketMaker */}
                     <AccountDetail
                         accountAddress="0x123451234512345"
                         avatarSrc="https://static.cryptotips.eu/wp-content/uploads/2019/05/binance-bnb-logo.png"
@@ -179,7 +178,7 @@ export const Account: React.FC<AccountProps> = () => {
                     subtitle="6,000 ZRX  →  0x12345...12345"
                     avatarSrc={MOCK_DATA.activitySummary.avatarSrc}
                 >
-                    <Button>
+                    <Button color="#fff">
                         Withdraw ZRX
                     </Button>
                 </AccountActivitySummary>

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -196,6 +196,7 @@ export const Account: React.FC<AccountProps> = () => {
                         fontSize="17px"
                         fontWeight="300"
                         padding="15px 35px"
+                        isFullWidth={true}
                     >
                         Withdraw ZRX
                     </Button>

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -211,7 +211,7 @@ export const Account: React.FC<AccountProps> = () => {
                 </SectionHeader>
 
                 <CallToAction
-                    icon="voting"
+                    icon="revenue"
                     title="You haven't staked ZRX"
                     description="Start staking your ZRX and getting interest."
                     actions={[

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import * as React from 'react';
+import * as ReactTooltip from 'react-tooltip';
 import styled from 'styled-components';
 
 import { Button } from 'ts/components/button';
@@ -10,6 +11,7 @@ import { StatFigure } from 'ts/components/ui/stat_figure';
 import { AccountActivitySummary } from 'ts/pages/account/account_activity_summary';
 import { AccountApplyModal } from 'ts/pages/account/account_apply_modal';
 import { AccountDetail } from 'ts/pages/account/account_detail';
+import { AccountFigure } from 'ts/pages/account/account_figure';
 import { AccountStakeOverview } from 'ts/pages/account/account_stake_overview';
 import { AccountVote } from 'ts/pages/account/account_vote';
 import { colors } from 'ts/style/colors';
@@ -88,11 +90,10 @@ export const Account: React.FC<AccountProps> = () => {
                     />
 
                     <Figures>
-                        <FigureItem>
-                            <header>
-                                Wallet balance
-
-                                <button>
+                        <AccountFigure
+                            label="Wallet balance"
+                            headerComponent={() => (
+                                <div data-tip={true} data-for="walletBalance">
                                     <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <g opacity="0.7">
                                             <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
@@ -100,13 +101,54 @@ export const Account: React.FC<AccountProps> = () => {
                                             <path d="M1 12H6.33333" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
                                         </g>
                                     </svg>
-                                </button>
-                            </header>
 
+                                    <ReactTooltip id="walletBalance">
+                                        This is the amount available for delegation starting in the next Epoch
+                                    </ReactTooltip>
+                                </div>
+                            )}
+                        >
                             21,000,000 ZRX
-                        </FigureItem>
+                        </AccountFigure>
 
-                        <FigureItem>
+                        <AccountFigure
+                            label="Staked balance"
+                            headerComponent={() => (
+                                <div data-tip={true} data-for="walletBalance">
+                                    <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <g opacity="0.7">
+                                            <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
+                                            <path d="M1 4.88867H3.66667V11.9998" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                                            <path d="M1 12H6.33333" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                                        </g>
+                                    </svg>
+
+                                    <ReactTooltip id="walletBalance">
+                                        This is the amount available for delegation starting in the next Epoch
+                                    </ReactTooltip>
+                                </div>
+                            )}
+                        >
+                            1,322,000 ZRX
+                        </AccountFigure>
+
+                        <AccountFigure
+                            label="Rewards"
+                            headerComponent={() => (
+                                <Button
+                                    isWithArrow={true}
+                                    isTransparent={true}
+                                    fontSize="17px"
+                                    color={colors.brandLight}
+                                >
+                                    Withdraw
+                                </Button>
+                            )}
+                        >
+                            .000213 ETH
+                        </AccountFigure>
+
+                        {/* <FigureItem>
                             <header>
                                 Staked Balance
 
@@ -122,24 +164,7 @@ export const Account: React.FC<AccountProps> = () => {
                             </header>
 
                             1,322,000 ZRX
-                        </FigureItem>
-
-                        <FigureItem>
-                            <header>
-                                Rewards
-
-                                <Button
-                                    isWithArrow={true}
-                                    isTransparent={true}
-                                    fontSize="17px"
-                                    color={colors.brandLight}
-                                >
-                                    Withdraw
-                                </Button>
-                            </header>
-
-                            .000213 ETH
-                        </FigureItem>
+                        </FigureItem> */}
                     </Figures>
                 </Inner>
             </HeaderWrapper>

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -85,10 +85,58 @@ export const Account: React.FC<AccountProps> = () => {
                     />
 
                     <Figures>
-                        {/* Note: replace this with figures component, shared with MarketMaker etc. */}
-                        <div>Figure</div>
-                        <div>Figure</div>
-                        <div>Figure</div>
+                        <FigureItem>
+                            <header>
+                                Wallet balance
+
+                                <button>
+                                    <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <g opacity="0.7">
+                                            <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
+                                            <path d="M1 4.88867H3.66667V11.9998" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                                            <path d="M1 12H6.33333" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                                        </g>
+                                    </svg>
+                                </button>
+                            </header>
+
+                            21,000,000 ZRX
+                        </FigureItem>
+
+                        <FigureItem>
+                            <header>
+                                Staked Balance
+
+                                <button>
+                                    <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <g opacity="0.7">
+                                            <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
+                                            <path d="M1 4.88867H3.66667V11.9998" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                                            <path d="M1 12H6.33333" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                                        </g>
+                                    </svg>
+                                </button>
+                            </header>
+
+                            1,322,000 ZRX
+                        </FigureItem>
+
+                        <FigureItem>
+                            <header>
+                                Rewards
+
+                                <Button
+                                    isWithArrow={true}
+                                    isTransparent={true}
+                                    fontSize="17px"
+                                    color={colors.brandLight}
+                                >
+                                    Withdraw
+                                </Button>
+                            </header>
+
+                            .000213 ETH
+                        </FigureItem>
                     </Figures>
                 </Inner>
             </HeaderWrapper>
@@ -150,7 +198,7 @@ export const Account: React.FC<AccountProps> = () => {
                         to="/account/activity"
                     >
                         Apply to create a staking pool
-                    </Button>
+                    </Button>to="/account/activity"
                 </SectionHeader>
 
                 <CallToAction
@@ -229,24 +277,45 @@ const Inner = styled.div`
 `;
 
 const Figures = styled.div`
-    div {
-        background-color: #fff;
-        padding: 20px;
-        width: 252px;
-        height: 94px;
-        text-align: left;
-    }
-
     @media (max-width: 1200px) {
         padding-top: 24px;
     }
 
     @media (min-width: 768px) {
         display: flex;
+    }
+`;
 
-        div + div {
-            margin-left: 12px;
+const FigureItem = styled.div`
+    background-color: #fff;
+    padding: 20px;
+    width: 252px;
+    height: 94px;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    font-size: 20px;
+
+    header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 17px;
+        color: #999;
+    }
+
+    button {
+        border: 0;
+        font-size: 17px;
+
+        svg {
+            height: 13px;
         }
+    }
+
+    & + & {
+        margin-left: 12px;
     }
 `;
 

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -286,11 +286,22 @@ const StyledTooltip = styled(ReactTooltip)`
         color: ${colors.textDarkPrimary};
         line-height: 1.5;
 
-        &:before {
-            border-top-color: ${colors.border} !important;
+        @media (min-width: 768px) {
+            &:before {
+                border-top-color: ${colors.border} !important;
+            }
+            &:after {
+                border-top-color: #f6f6f6 !important;
+            }
         }
-        &:after {
-            border-top-color: #f6f6f6 !important;
+
+        @media (max-width: 768px) {
+            &:before {
+                border-left-color: ${colors.border} !important;
+            }
+            &:after {
+                border-left-color: #f6f6f6 !important;
+            }
         }
     }
     &.tooltip-light.border {

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -321,8 +321,14 @@ const FigureItem = styled.div`
         }
     }
 
-    & + & {
-        margin-left: 12px;
+    @media (min-width: 768px) {
+        & + & {
+            margin-left: 12px;
+        }
+    }
+
+    @media (max-width: 768px) {
+        width: 100%;
     }
 `;
 

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -178,7 +178,14 @@ export const Account: React.FC<AccountProps> = () => {
                     subtitle="6,000 ZRX  →  0x12345...12345"
                     avatarSrc={MOCK_DATA.activitySummary.avatarSrc}
                 >
-                    <Button color="#fff">
+                    <Button
+                        to="/"
+                        color={colors.brandLight}
+                        bgColor={colors.white}
+                        fontSize="17px"
+                        fontWeight="300"
+                        padding="15px 35px"
+                    >
                         Withdraw ZRX
                     </Button>
                 </AccountActivitySummary>
@@ -309,11 +316,13 @@ const FigureItem = styled.div`
         align-items: center;
         font-size: 17px;
         color: #999;
+        font-weight: 200;
     }
 
     button {
         border: 0;
         font-size: 17px;
+        font-weight: 200;
 
         svg {
             height: 13px;

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -8,6 +8,7 @@ import { StakingPageLayout } from 'ts/components/staking/layout/staking_page_lay
 import { Heading } from 'ts/components/text';
 import { StatFigure } from 'ts/components/ui/stat_figure';
 import { AccountActivitySummary } from 'ts/pages/account/account_activity_summary';
+import { AccountApplyModal } from 'ts/pages/account/account_apply_modal';
 import { AccountDetail } from 'ts/pages/account/account_detail';
 import { AccountStakeOverview } from 'ts/pages/account/account_stake_overview';
 import { AccountVote } from 'ts/pages/account/account_vote';
@@ -74,6 +75,8 @@ const MOCK_DATA = {
 };
 
 export const Account: React.FC<AccountProps> = () => {
+    const [isApplyModalOpen, toggleApplyModal] = React.useState(false);
+
     return (
         <StakingPageLayout title="0x Staking | Account">
             <HeaderWrapper>
@@ -195,10 +198,10 @@ export const Account: React.FC<AccountProps> = () => {
                     <Button
                         isWithArrow={true}
                         isTransparent={true}
-                        to="/account/activity"
+                        onClick={() => toggleApplyModal(true)}
                     >
                         Apply to create a staking pool
-                    </Button>to="/account/activity"
+                    </Button>
                 </SectionHeader>
 
                 <CallToAction
@@ -247,6 +250,10 @@ export const Account: React.FC<AccountProps> = () => {
                     })}
                 </Grid>
             </SectionWrapper>
+
+            <AccountApplyModal
+                isOpen={isApplyModalOpen}
+                onDismiss={() => toggleApplyModal(false)} />
         </StakingPageLayout>
     );
 };

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -162,6 +162,7 @@ export const Account: React.FC<AccountProps> = () => {
                     </Heading>
 
                     <Button
+                        color={colors.brandDark}
                         isWithArrow={true}
                         isTransparent={true}
                         to="/account/activity"
@@ -212,6 +213,7 @@ export const Account: React.FC<AccountProps> = () => {
                     </Heading>
 
                     <Button
+                        color={colors.brandDark}
                         isWithArrow={true}
                         isTransparent={true}
                         onClick={() => toggleApplyModal(true)}

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -93,7 +93,7 @@ export const Account: React.FC<AccountProps> = () => {
                         <AccountFigure
                             label="Wallet balance"
                             headerComponent={() => (
-                                <div data-tip={true} data-for="walletBalance">
+                                <div data-tip={true} data-for="walletBalance" data-border="true">
                                     <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <g opacity="0.7">
                                             <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
@@ -102,9 +102,9 @@ export const Account: React.FC<AccountProps> = () => {
                                         </g>
                                     </svg>
 
-                                    <ReactTooltip id="walletBalance">
+                                    <StyledTooltip id="walletBalance" className="tooltip-light">
                                         This is the amount available for delegation starting in the next Epoch
-                                    </ReactTooltip>
+                                    </StyledTooltip>
                                 </div>
                             )}
                         >
@@ -114,7 +114,7 @@ export const Account: React.FC<AccountProps> = () => {
                         <AccountFigure
                             label="Staked balance"
                             headerComponent={() => (
-                                <div data-tip={true} data-for="walletBalance">
+                                <div data-tip={true} data-for="stakedBalance" data-border="true">
                                     <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <g opacity="0.7">
                                             <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
@@ -123,9 +123,9 @@ export const Account: React.FC<AccountProps> = () => {
                                         </g>
                                     </svg>
 
-                                    <ReactTooltip id="walletBalance">
+                                    <StyledTooltip id="stakedBalance" className="tooltip-light">
                                         This is the amount available for delegation starting in the next Epoch
-                                    </ReactTooltip>
+                                    </StyledTooltip>
                                 </div>
                             )}
                         >
@@ -147,24 +147,6 @@ export const Account: React.FC<AccountProps> = () => {
                         >
                             .000213 ETH
                         </AccountFigure>
-
-                        {/* <FigureItem>
-                            <header>
-                                Staked Balance
-
-                                <button>
-                                    <svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <g opacity="0.7">
-                                            <path d="M3.61176 0.888889C3.61176 1.10367 3.43765 1.27778 3.22287 1.27778C3.0081 1.27778 2.83398 1.10367 2.83398 0.888889C2.83398 0.674111 3.0081 0.5 3.22287 0.5C3.43765 0.5 3.61176 0.674111 3.61176 0.888889Z" fill="white" stroke="#5C5C5C"/>
-                                            <path d="M1 4.88867H3.66667V11.9998" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-                                            <path d="M1 12H6.33333" stroke="#5C5C5C" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </g>
-                                    </svg>
-                                </button>
-                            </header>
-
-                            1,322,000 ZRX
-                        </FigureItem> */}
                     </Figures>
                 </Inner>
             </HeaderWrapper>
@@ -293,6 +275,27 @@ export const Account: React.FC<AccountProps> = () => {
     );
 };
 
+const StyledTooltip = styled(ReactTooltip)`
+    &.tooltip-light {
+        background-color: #f6f6f6;
+        max-width: 390px;
+        padding: 20px;
+        font-size: 18px;
+        color: ${colors.textDarkPrimary};
+        line-height: 1.5;
+
+        &:before {
+            border-top-color: ${colors.border} !important;
+        }
+        &:after {
+            border-top-color: #f6f6f6 !important;
+        }
+    }
+    &.tooltip-light.border {
+        border: 1px solid ${colors.border};
+    }
+`;
+
 const HeaderWrapper = styled.div`
     width: 100%;
     max-width: 1500px;
@@ -325,47 +328,6 @@ const Figures = styled.div`
 
     @media (min-width: 768px) {
         display: flex;
-    }
-`;
-
-const FigureItem = styled.div`
-    background-color: #fff;
-    padding: 20px;
-    width: 252px;
-    height: 94px;
-    text-align: left;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    font-size: 20px;
-
-    header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 17px;
-        color: #999;
-        font-weight: 200;
-    }
-
-    button {
-        border: 0;
-        font-size: 17px;
-        font-weight: 200;
-
-        svg {
-            height: 13px;
-        }
-    }
-
-    @media (min-width: 768px) {
-        & + & {
-            margin-left: 12px;
-        }
-    }
-
-    @media (max-width: 768px) {
-        width: 100%;
     }
 `;
 

--- a/ts/pages/account/history.tsx
+++ b/ts/pages/account/history.tsx
@@ -140,4 +140,10 @@ const ContentWrap = styled.div`
     width: calc(100% - 40px);
     max-width: 1152px;
     margin: 90px auto 0 auto;
+
+    @media (max-width: 768px) {
+        h1 {
+            font-size: 34px;
+        }
+    }
 `;

--- a/ts/pages/governance/vote_index_card.tsx
+++ b/ts/pages/governance/vote_index_card.tsx
@@ -82,7 +82,7 @@ export const VoteIndexCard: React.StatelessComponent<VoteIndexCardProps> = ({
                 <FlexWrap>
                     <Column width="60%" padding="0px 20px 0px 0px">
                         <Heading>
-                            {`${title} `}
+                            {`${title} `} sdf
                             <Muted>{`(ZEIP-${zeipId})`}</Muted>
                         </Heading>
 


### PR DESCRIPTION
Adds UI elements previously with placeholders, added interactive elements, styling polish

- Adds figures in account header
- Polishes account dashboard page mobile styling
- Adds signup staking node modal (with mock actions)
- Adds tooltips to account header figures, uses existing ReactTooltip
- Adds `darken` method to `Button` component's hover style to darken provided bgColor prop

![screencapture-localhost-3572-account-2019-10-15-11_18_34](https://user-images.githubusercontent.com/4451733/66818450-a44c0600-ef3d-11e9-82fb-71b672ec0e4a.png)
![image](https://user-images.githubusercontent.com/4451733/66818459-a615c980-ef3d-11e9-9ac1-80db4a3b0b0d.png)
