### PR TITLE
Removes history/activity table name column subtitles on mobile

### DIFF
--- a/ts/components/ui/table_stake_status.tsx
+++ b/ts/components/ui/table_stake_status.tsx
@@ -6,6 +6,7 @@ import { colors } from 'ts/style/colors';
 interface StakeStatus {
     title: string;
     subtitle: string;
+    className?: string;
 }
 
 interface StatusColors {
@@ -19,9 +20,10 @@ interface StatusTextProps {
 export const StakeStatus: React.StatelessComponent<StakeStatus> = ({
     subtitle,
     title,
+    className,
 }) => {
     return (
-        <>
+        <div className={className}>
             <StatusText status={title}>
                 {title}
             </StatusText>
@@ -29,7 +31,7 @@ export const StakeStatus: React.StatelessComponent<StakeStatus> = ({
             <StatusId>
                 {subtitle}
             </StatusId>
-        </>
+        </div>
     );
 };
 

--- a/ts/pages/account/activity.tsx
+++ b/ts/pages/account/activity.tsx
@@ -118,7 +118,7 @@ export const AccountActivity: React.FC = () => {
                                     {row.date}
                                 </DateCell>
                                 <td>
-                                    <StakeStatus
+                                    <StyledStakeStatus
                                         title={description.title}
                                         subtitle={description.subtitle}
                                     />
@@ -164,5 +164,13 @@ const DateCell = styled.td`
         display: block;
         margin-bottom: 10px;
         color: ${colors.textDarkPrimary}
+    }
+`;
+
+const StyledStakeStatus = styled(StakeStatus)`
+    @media (max-width: 768px) {
+        span {
+            display: none;
+        }
     }
 `;

--- a/ts/pages/account/history.tsx
+++ b/ts/pages/account/history.tsx
@@ -118,7 +118,7 @@ export const AccountHistory: React.FC = () => {
                                     {row.date}
                                 </DateCell>
                                 <td>
-                                    <StakeStatus
+                                    <StyledStakeStatus
                                         title={description.title}
                                         subtitle={description.subtitle}
                                     />
@@ -164,5 +164,13 @@ const DateCell = styled.td`
         display: block;
         margin-bottom: 10px;
         color: ${colors.textDarkPrimary}
+    }
+`;
+
+const StyledStakeStatus = styled(StakeStatus)`
+    @media (max-width: 768px) {
+        span {
+            display: none;
+        }
     }
 `;


### PR DESCRIPTION
On mobile, the tables for activity and history are a bit crowded with long descriptions, this hides it on mobile.