### PR TITLE
Fix Governance page styling and Section component props being applied twice

### DIFF
--- a/ts/components/newLayout.tsx
+++ b/ts/components/newLayout.tsx
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -61,9 +62,21 @@ export const Section: React.FunctionComponent<SectionProps> = (props: SectionPro
     if (props.omitWrapper) {
         return <SectionBase {...props} />;
     }
+    const wrapProps = _.pick(props, [
+        'bgColor',
+        'id',
+        'offsetTop',
+        'maxWidth',
+        'wrapWidth',
+        'isFullWidh',
+        'isTextCentered',
+        'isCentered',
+        'isWrapped',
+    ]);
+
     return (
         <SectionBase {...props}>
-            <Wrap {...props}>{props.children}</Wrap>
+            <Wrap {...wrapProps}>{props.children}</Wrap>
         </SectionBase>
     );
 };

--- a/ts/pages/governance/vote_index.tsx
+++ b/ts/pages/governance/vote_index.tsx
@@ -45,7 +45,7 @@ export class VoteIndex extends React.Component<VoteIndexProps, VoteIndexState> {
         return (
             <SiteWrap>
                 <DocumentTitle {...documentConstants.VOTE} />
-                <Section isTextCentered={true} isPadded={true} padding="150px 0px 110px">
+                <Section isTextCentered={true} isPadded={true} padding="80px 0 80px">
                     <Column>
                         <Heading size="medium" isCentered={true}>
                             0x Protocol Governance


### PR DESCRIPTION
I think this fixes the underlying issue which was that the styling being passed to the Section component unintentionally was being passed to the inner wrapper component as well. The lead to margin and paddings begin applied twice.

@chriskalani there also is a rather large margin of `150px` being added after the vote cards section. Should that remain?

![image](https://user-images.githubusercontent.com/5450545/67981540-2cf6c180-fc21-11e9-8d1d-f7908e2f42fc.png)