### PR TITLE
docs: Add Github docs guide and link to it from version picker

### DIFF
--- a/mdx/guides/browsing-docs-on-github.mdx
+++ b/mdx/guides/browsing-docs-on-github.mdx
@@ -1,0 +1,33 @@
+Our website currently only renders the docs for the latest version of each tool. Since August 26th, 2019 we have been generating markdown docs for our packages and committing them to the [0x-monorepo](https://github.com/0xProject/0x-monorepo) on Github on every release.
+
+# Step-by-step Walkthrough
+
+This guide will walk you through how to find the docs for an older version of one of our packages on Github.
+
+As an example, let's say you wanted to find the docs for version `5.0.19` of the `@0x/connect` package. The first step would be to visit the release tag page for this version and library:
+
+
+[https://github.com/0xProject/0x-monorepo/releases/tag/%400x%2Fconnect%405.0.19](https://github.com/0xProject/0x-monorepo/releases/tag/%400x%2Fconnect%405.0.19)
+
+
+You can replace the package name and version number in the URL encoded string above. Note that `%40` encodes for the `@` sign.
+
+
+<Image src="https://0x-wiki-images.s3.eu-west-2.amazonaws.com/tag_page_github.png" align="center" marginBottom="4rem"/>
+
+Click on the Git commit hash link in the left sidebar. This will bring you to the publish commit for this version of the library.
+
+<Image src="https://0x-wiki-images.s3.eu-west-2.amazonaws.com/browse_files_github.png" align="center" marginBottom="4rem"/>
+
+Now click "Browse files" in order to browse all the files at this particular point in time.
+
+<Image src="https://0x-wiki-images.s3.eu-west-2.amazonaws.com/find_file_github.png" align="center" marginBottom="4rem"/>
+
+On the right you should see that we're browsing the file at the release commit (Boxed in red above). By clicking the "Find file" button to find a specific file. The file we are looking for is the `docs/reference.mdx` file within the `packages/connect` directory. This contains the markdown documentation for the `@0x/connect` library.
+
+<Image src="https://0x-wiki-images.s3.eu-west-2.amazonaws.com/find_file_search_github.png" align="center" marginBottom="4rem"/>
+
+By typing `connect/reference` into the search bar, the `reference.mdx` file for `@0x/connect` will show up and clicking on it will bring you to the MDX docs. The MDX will be rendered for you by Github.
+
+<Image src="https://0x-wiki-images.s3.eu-west-2.amazonaws.com/md_docs_github.png" align="center" marginBottom="4rem"/>
+

--- a/ts/components/docs/sidebar/version_picker.tsx
+++ b/ts/components/docs/sidebar/version_picker.tsx
@@ -5,6 +5,9 @@ import styled from 'styled-components';
 import { Paragraph } from 'ts/components/text';
 
 import { colors } from 'ts/style/colors';
+import { constants } from 'ts/utils/constants';
+
+const OTHER_VERSION = 'OTHER';
 
 interface IVersionPickerProps extends RouteComponentProps<IMatchParams> {
     versions: string[];
@@ -21,7 +24,10 @@ const VersionSelect: React.FC<IVersionPickerProps> = ({ history, location, match
 
     const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const version = e.target.value;
-        const url = `/docs/${type}/${page}/${version}`;
+        let url = `/docs/${type}/${page}/${version}`;
+        if (version === OTHER_VERSION) {
+           url = `/docs/guides/${constants.GUIDE_OLDER_VERSIONS}`;
+        }
         history.push(url);
         window.scrollTo(0, 0);
     };
@@ -45,6 +51,9 @@ const VersionSelect: React.FC<IVersionPickerProps> = ({ history, location, match
                             {getNumericVersion(version)}
                         </option>
                     ))}
+                    <option key={OTHER_VERSION} value={OTHER_VERSION}>
+                            Older versions
+                    </option>
                 </StyledSelect>
                 <svg width="12" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M1 7l5-5 5 5" stroke={colors.brandDark} strokeWidth="1.5" />

--- a/ts/utils/algolia_meta.json
+++ b/ts/utils/algolia_meta.json
@@ -22,6 +22,15 @@
             "difficulty": "Intermediate",
             "path": "guides/create-staking-pool.mdx"
         },
+        "browsing-docs-on-github": {
+            "title": "How to browse docs on Github",
+            "subtitle": "How to find the docs for older versions of 0x libraries on Github",
+            "description": "How to find the docs for older versions of 0x libraries on Github",
+            "tags": ["Testing", "Relayer", "Protocol Developer", "Trader"],
+            "topics": ["Testing", "Relayer", "Protocol Developer", "Trader"],
+            "difficulty": "Intermediate",
+            "path": "guides/browsing-docs-on-github.mdx"
+        },
         "mesh-beta-participation-guide": {
             "title": "0x Mesh beta participation guide",
             "description": "Learn how to spin up a telemetry-enabled Mesh node and participate in the Beta!",

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -20,6 +20,7 @@ export const constants = {
         3: 1719261,
         4: 1570919,
     } as { [networkId: number]: number },
+    GUIDE_OLDER_VERSIONS: 'browsing-docs-on-github',
     HOME_SCROLL_DURATION_MS: 500,
     HTTP_NO_CONTENT_STATUS_CODE: 204,
     LOCAL_STORAGE_KEY_ACCEPT_DISCLAIMER: 'didAcceptPortalDisclaimer',


### PR DESCRIPTION
This PR: Adds a "older versions" option in all doc version pickers that re-direct to a new guide on how to browse older version docs for our packages on Github.

<img width="400" alt="Screenshot 2019-11-15 at 13 38 51" src="https://user-images.githubusercontent.com/2151492/68947690-ffc41a80-07ad-11ea-9f0b-cdd7a5a8149b.png">

<img width="1431" alt="Screenshot 2019-11-15 at 13 39 05" src="https://user-images.githubusercontent.com/2151492/68947695-0357a180-07ae-11ea-8202-f9dba6a56085.png">
