### PR TITLE
Fix asset-swap page React crash when slippage data is missing

### DIFF
--- a/ts/pages/cfl/cfl_metrics.tsx
+++ b/ts/pages/cfl/cfl_metrics.tsx
@@ -142,8 +142,8 @@ export class CFLMetrics extends React.Component<CFLMetricsProps, CFLMetricsState
     }
     private _getSlippageMetrics(): MetricValue[] {
         const data = this._getSelectedPairData();
+        const placeholder = '—';
         if (!data.exchangeAverageSlippagePercentage) {
-            const placeholder = '—';
             return [
                 {
                     label: <Icon name="small_0x_logo" size="natural" />,
@@ -172,15 +172,15 @@ export class CFLMetrics extends React.Component<CFLMetricsProps, CFLMetricsState
         return [
             {
                 label: <Icon name="small_0x_logo" size="natural" />,
-                value: formatSlippage(zeroExSlippage.slippage),
+                value: zeroExSlippage ? formatSlippage(zeroExSlippage.slippage) : placeholder,
             },
             {
                 label: <Icon name="small_kyber_logo" size="natural" />,
-                value: formatSlippage(kyberSlippage.slippage),
+                value: kyberSlippage ? formatSlippage(kyberSlippage.slippage) : placeholder,
             },
             {
                 label: <Icon name="small_uniswap_logo" size="natural" />,
-                value: formatSlippage(uniswapSlippage.slippage),
+                value: uniswapSlippage ? formatSlippage(uniswapSlippage.slippage) : placeholder,
             },
         ];
     }


### PR DESCRIPTION
https://0x.org/asset-swapper has a bug where if you click the DAI/USDC pairs React crashes and unmounts the page.

This is due to DAI/USDC returning a null slippage pair, and not caught by TS because `strictNullChecks: false` in our `tsconfig.json`.

This is a quick bandaid fix until we can fix the data source. Long term we should also implement some ErrorBoundary components and perhaps look into turning strictNullChecks on.