### PR TITLE
Fix CircleCI failure (Issue when installing specific yarn version)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
               - checkout
               - run:
                   name: install-yarn
-                  command: npm install --global yarn@1.17.0
+                  command: npm install --global --force yarn@1.17.0
               - run:
                   name: yarn
                   command: yarn --frozen-lockfile --ignore-engines install || yarn --frozen-lockfile --ignore-engines install


### PR DESCRIPTION
CircleCI suddenly has permission problems installing yarn@1.17.0. Adding `--force` fixes the issue.