### PR TITLE
Feature: Support for formatting numbers in staking dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build:prod": "node --max_old_space_size=16384 ./node_modules/webpack/bin/webpack.js --mode production",
         "build:dev": "node --max-old-space-size=16384 ./node_modules/webpack/bin/webpack.js --mode development",
         "clean": "shx rm -rf public/bundle* mdx/tools",
-        "test": "jest --passWithNoTests",
+        "test": "jest",
         "test:watch": "jest --watch",
         "eslint": "eslint 'ts/**/*.{ts,tsx}'",
         "lint": "tslint --format stylish --project . 'ts/**/*.ts' 'ts/**/*.tsx'",

--- a/ts/utils/format_number.test.ts
+++ b/ts/utils/format_number.test.ts
@@ -1,0 +1,146 @@
+import { BigNumber } from '@0x/utils';
+
+import { formatEther, formatNumber, formatPercent, formatZrx } from './format_number';
+
+describe('formatNumber', () => {
+    test('should minimize numbers', () => {
+        const lotsOfZeroes = formatNumber('1.12000000', {
+            decimals: 6,
+            decimalsRounded: 6,
+        });
+        expect(lotsOfZeroes.minimized).toBe('1.12');
+    });
+    test('can optionally postfix big numbers', () => {
+        const hundredMillion = formatNumber('100000000', {
+            decimals: 6,
+            decimalsRounded: 6,
+            bigUnitPostfix: true,
+        });
+        expect(hundredMillion.formatted).toBe('100M');
+    });
+    test('should work with string type', () => {
+        const hundredMillion = formatNumber('1.2345', {
+            decimals: 2,
+            decimalsRounded: 2,
+        });
+        expect(hundredMillion.formatted).toBe('1.23');
+    });
+    test('should work with number type', () => {
+        const hundredMillion = formatNumber(1.2345, {
+            decimals: 2,
+            decimalsRounded: 2,
+        });
+        expect(hundredMillion.formatted).toBe('1.23');
+    });
+    test('should work with BigNumber type', () => {
+        const hundredMillion = formatNumber(new BigNumber(1.2345), {
+            decimals: 2,
+            decimalsRounded: 2,
+        });
+        expect(hundredMillion.formatted).toBe('1.23');
+    });
+});
+
+describe('formatPercent', () => {
+    // Happy path
+    test('should format a basic percent', () => {
+        const formattedNum = formatPercent(12.567);
+        expect(formattedNum.formatted).toBe('12.57');
+        expect(formattedNum.formattedValue).toBe(12.57);
+        expect(formattedNum.denomination).toBe('%');
+    });
+
+    // Edge cases
+    test('should round up 99.999 to 100', () => {
+        // TODO(johnrjj) - verify this is ok to round up ?
+        const almostOneHundredPercent = formatPercent(99.999);
+        expect(almostOneHundredPercent.formattedValue).toBe(100);
+        expect(almostOneHundredPercent.formatted).toBe('100.00');
+        expect(almostOneHundredPercent.full).toBe('100.00%');
+        expect(almostOneHundredPercent.fullPrecision).toBe('99.999');
+    });
+
+    test('should round down 0.001 to 0.00', () => {
+        const almostZero = formatPercent(0.001);
+        expect(almostZero.formatted).toBe('0.00');
+    });
+
+    test('should accept percents over 100', () => {
+        const over100Percent = formatPercent(101.42);
+        expect(over100Percent.formatted).toBe('101.42');
+        expect(over100Percent.full).toBe('101.42%');
+    });
+});
+
+describe('formatEther', () => {
+    test('should format a basic amount (rounds up - even)', () => {
+        const endsInEven = formatEther(12.123456789);
+        expect(endsInEven.formatted).toBe('12.12346');
+        expect(endsInEven.formattedValue).toBe(12.12346);
+        expect(endsInEven.denomination).toBe(' ETH');
+        expect(endsInEven.full).toBe('12.12346 ETH');
+    });
+
+    test('should format a basic amount (rounds down - odd)', () => {
+        const endsInOdd = formatEther(12.123453);
+        expect(endsInOdd.formatted).toBe('12.12345');
+        expect(endsInOdd.formattedValue).toBe(12.12345);
+        expect(endsInOdd.full).toBe('12.12345 ETH');
+    });
+
+    test('should format a basic amount (rounds up - boundary)', () => {
+        const endsInFive = formatEther(12.123455);
+        expect(endsInFive.formatted).toBe('12.12346');
+        expect(endsInFive.formattedValue).toBe(12.12346);
+        expect(endsInFive.full).toBe('12.12346 ETH');
+    });
+
+    test('should format a dust amount of ether to zero (rounds down)', () => {
+        const notEnoughEtherToShow = formatEther(0.000001);
+        expect(notEnoughEtherToShow.formatted).toBe('0.00000');
+        expect(notEnoughEtherToShow.full).toBe('0.00000 ETH');
+    });
+
+    test('should format a small amount of ether to zero (rounds down)', () => {
+        const justEnoughEtherToShow = formatEther(0.00001);
+        expect(justEnoughEtherToShow.formatted).toBe('0.00001');
+        expect(justEnoughEtherToShow.full).toBe('0.00001 ETH');
+    });
+
+    test('should format a integer amount', () => {
+        const wholeNumber = formatEther(12);
+        expect(wholeNumber.formatted).toBe('12.00000');
+        expect(wholeNumber.full).toBe('12.00000 ETH');
+    });
+
+    test('should add commas', () => {
+        const millionEther = formatEther(1000000);
+        expect(millionEther.formatted).toBe('1,000,000.00000');
+        expect(millionEther.full).toBe('1,000,000.00000 ETH');
+    });
+});
+
+describe('formatZrx', () => {
+    test('should format to two digits', () => {
+        const shouldBeRoundedToTwoDigits = formatZrx(1.123456789);
+        expect(shouldBeRoundedToTwoDigits.formattedValue).toBe(1.12);
+        expect(shouldBeRoundedToTwoDigits.denomination).toBe(' ZRX');
+        expect(shouldBeRoundedToTwoDigits.formatted).toBe('1.12');
+        expect(shouldBeRoundedToTwoDigits.full).toBe('1.12 ZRX');
+        expect(shouldBeRoundedToTwoDigits.fullPrecision).toBe('1.123456789');
+    });
+
+    test('should round down', () => {
+        const shouldBeRoundedToTwoDigits = formatZrx(1.999999);
+        expect(shouldBeRoundedToTwoDigits.formattedValue).toBe(1.99);
+        expect(shouldBeRoundedToTwoDigits.formatted).toBe('1.99');
+        expect(shouldBeRoundedToTwoDigits.full).toBe('1.99 ZRX');
+        expect(shouldBeRoundedToTwoDigits.fullPrecision).toBe('1.999999');
+    });
+
+    test('should add commas', () => {
+        const millionZrx = formatZrx(1000000);
+        expect(millionZrx.formatted).toBe('1,000,000.00');
+        expect(millionZrx.full).toBe('1,000,000.00 ZRX');
+    });
+});

--- a/ts/utils/format_number.test.ts
+++ b/ts/utils/format_number.test.ts
@@ -10,6 +10,7 @@ describe('formatNumber', () => {
         });
         expect(lotsOfZeroes.minimized).toBe('1.12');
     });
+
     test('can optionally postfix big numbers', () => {
         const hundredMillion = formatNumber('100000000', {
             decimals: 6,
@@ -18,6 +19,7 @@ describe('formatNumber', () => {
         });
         expect(hundredMillion.formatted).toBe('100M');
     });
+
     test('should work with string type', () => {
         const hundredMillion = formatNumber('1.2345', {
             decimals: 2,
@@ -25,6 +27,7 @@ describe('formatNumber', () => {
         });
         expect(hundredMillion.formatted).toBe('1.23');
     });
+
     test('should work with number type', () => {
         const hundredMillion = formatNumber(1.2345, {
             decimals: 2,
@@ -32,6 +35,7 @@ describe('formatNumber', () => {
         });
         expect(hundredMillion.formatted).toBe('1.23');
     });
+
     test('should work with BigNumber type', () => {
         const hundredMillion = formatNumber(new BigNumber(1.2345), {
             decimals: 2,

--- a/ts/utils/format_number.test.ts
+++ b/ts/utils/format_number.test.ts
@@ -77,12 +77,12 @@ describe('formatPercent', () => {
 });
 
 describe('formatEther', () => {
-    test('should format a basic amount (rounds up - even)', () => {
+    test('should format a basic amount (rounds down - even)', () => {
         const endsInEven = formatEther(12.123456789);
-        expect(endsInEven.formatted).toBe('12.12346');
-        expect(endsInEven.formattedValue).toBe(12.12346);
+        expect(endsInEven.formatted).toBe('12.12345');
+        expect(endsInEven.formattedValue).toBe(12.12345);
         expect(endsInEven.denomination).toBe(' ETH');
-        expect(endsInEven.full).toBe('12.12346 ETH');
+        expect(endsInEven.full).toBe('12.12345 ETH');
     });
 
     test('should format a basic amount (rounds down - odd)', () => {
@@ -94,9 +94,9 @@ describe('formatEther', () => {
 
     test('should format a basic amount (rounds up - boundary)', () => {
         const endsInFive = formatEther(12.123455);
-        expect(endsInFive.formatted).toBe('12.12346');
-        expect(endsInFive.formattedValue).toBe(12.12346);
-        expect(endsInFive.full).toBe('12.12346 ETH');
+        expect(endsInFive.formatted).toBe('12.12345');
+        expect(endsInFive.formattedValue).toBe(12.12345);
+        expect(endsInFive.full).toBe('12.12345 ETH');
     });
 
     test('should format a dust amount of ether to zero (rounds down)', () => {

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -60,8 +60,6 @@ export const createBigNumber = (value: NumStrBigNumber, base?: number): BigNumbe
   };
 
 export const ZERO = createBigNumber(0);
-export const ONE = createBigNumber(1, 10);
-export const TWO = createBigNumber(2, 10);
 export const TEN = createBigNumber(10, 10);
 
 export const ETHER_NUMBER_OF_DECIMALS = 5;

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -185,8 +185,6 @@ export function formatNumber(
   positiveSign = !!positiveSign;
   roundUp = !!roundUp;
   roundDown = !!roundDown;
-  zeroStyled = zeroStyled;
-  blankZero = blankZero;
 
   if (value.eq(ZERO)) {
     if (zeroStyled) { return formatNone(); }

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -3,6 +3,7 @@ import { BigNumber } from '@0x/utils';
 // tslint:disable: boolean-naming
 // tslint:disable: prefer-template
 // tslint:disable: prefer-const
+// tslint:disable: restrict-plus-operands
 
 // Code logic borrowed from our friends at Augur :) (v2 codebase)
 
@@ -45,6 +46,7 @@ export const createBigNumber = (value: NumStrBigNumber, base?: number): BigNumbe
     try {
       let useValue = value;
       if (typeof value === 'object' && Object.keys(value).indexOf('_hex') > -1) {
+        // tslint:disable-next-line: no-unnecessary-type-assertion
         useValue = (value as any)._hex;
       }
       newBigNumber = new BigNumber(`${useValue}`, base);

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -341,6 +341,7 @@ export function formatEther(
     positiveSign: false,
     zeroStyled: false,
     blankZero: false,
+    roundDown: true, // round down to be safe and avoid ui mismatches
     bigUnitPostfix: false,
     ...opts,
   });

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -275,9 +275,6 @@ export function formatNumber(
     o.roundedFormatted = bigUnitPostfix
       ? addBigUnitPostfix(value, o.roundedValue.toFixed(decimalsRounded), removeComma)
       : addCommas(o.roundedValue.toFixed(decimalsRounded), removeComma);
-    // o.minimized = addCommas(encodeNumberAsBase10String(o.formattedValue), removeComma);
-    // o.rounded = encodeNumberAsBase10String(o.roundedValue);
-    // o.formattedValue = encodeNumberAsJSNumber(o.formattedValue, false);
     o.minimized = addCommas(new BigNumber(o.formattedValue, 10).toFixed(), removeComma);
     o.rounded = o.roundedValue.toFixed();
     o.formattedValue = new BigNumber(o.formattedValue, 10).toNumber();

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -1,0 +1,367 @@
+import { BigNumber } from '@0x/utils';
+
+// tslint:disable: boolean-naming
+// tslint:disable: prefer-template
+// tslint:disable: prefer-const
+
+// Code logic borrowed from our friends at Augur :) (v2 codebase)
+
+/*
+The formatted number object that is returned looks something like this:
+  {
+    value: the parsed number in numerical form, 0 if a bad input was passed in, can be used in calculations
+
+    formattedValue: the value in numerical form, possibly rounded, can be used in calculations
+    formatted: the value in string form with possibly additional formatting, like comma separator, used for display
+
+    o.roundedValue: the value in numerical form, with extra rounding, can be used in calculations
+    o.rounded: the value in string form, with extra rounding
+    o.roundedFormatted: the value in string form, with formatting, like comma separator, used for display
+
+    o.minimized: the value in string form, with trailing 0 decimals omitted, for example if the `formatted` value is 1.00, this minimized value would be 1
+  }
+
+The reason the number object has multiple states of rounding simultaneously,
+is because the ui can use it for multiple purposes. For example, when showing ether,
+we generally like to show it with 5 decimals, however when used in totals,
+maximum precision is not necessary, and we can opt to show the `rounded` display, which is only 1 decimal.
+Similar logic applies for `minimized`, sometimes we don't need to be consistent with the decimals
+and just show the prettiest, smallest representation of the value.
+
+The options object that is passed into `formatNumber` that enables all of this looks like:
+  {
+    decimals: the number of decimals for the precise case, can be 0-infinity
+    decimalsRounded: the number of decimals for the prettier case, can be 0-infinity
+    denomination: the string denomination of the number (ex. Eth, Rep, %), can be blank
+    positiveSign: boolean whether to include a plus sign at the beginning of positive numbers
+    zeroStyled: boolean, if true, when the value is 0, it formates it as a dash (-) instead
+  }
+*/
+
+export type NumStrBigNumber = number | BigNumber | string;
+
+export const createBigNumber = (value: NumStrBigNumber, base?: number): BigNumber => {
+    let newBigNumber;
+    try {
+      let useValue = value;
+      if (typeof value === 'object' && Object.keys(value).indexOf('_hex') > -1) {
+        useValue = (value as any)._hex;
+      }
+      newBigNumber = new BigNumber(`${useValue}`, base);
+    } catch (e) {
+        // tslint:disable-next-line: no-console
+        console.error('Error instantiating WrappedBigNumber', e);
+        throw new Error(e);
+    }
+
+    return newBigNumber;
+  };
+
+export const ZERO = createBigNumber(0);
+export const ONE = createBigNumber(1, 10);
+export const TWO = createBigNumber(2, 10);
+export const TEN = createBigNumber(10, 10);
+
+export const ETHER_NUMBER_OF_DECIMALS = 5;
+export const ZRX_NUMBER_OF_DECIMALS = 2;
+
+export const SMALLEST_NUMBER_DECIMAL_PLACES = 8;
+export const USUAL_NUMBER_DECIMAL_PLACES = 4;
+
+export interface FormattedNumber {
+  fullPrecision: number | string;
+  roundedValue: number | BigNumber;
+  roundedFormatted: string;
+  formatted: string;
+  formattedValue: number | string;
+  denomination: string;
+  minimized: string;
+  value: number;
+  rounded: number | string;
+  full: number | string;
+}
+
+export interface FormattedNumberOptions {
+  decimals?: number;
+  decimalsRounded?: number;
+  denomination?: (value: string) => string;
+  roundUp?: boolean;
+  roundDown?: boolean;
+  positiveSign?: boolean;
+  zeroStyled?: boolean;
+  minimized?: boolean;
+  blankZero?: boolean;
+  bigUnitPostfix?: boolean;
+  removeComma?: boolean;
+}
+
+function formatNone(): FormattedNumber {
+  return {
+    value: 0,
+    formattedValue: 0,
+    formatted: '-',
+    roundedValue: 0,
+    rounded: '-',
+    roundedFormatted: '-',
+    minimized: '-',
+    denomination: '',
+    full: '-',
+    fullPrecision: '0',
+  };
+}
+
+function formatBlank(): FormattedNumber {
+  return {
+    value: 0,
+    formattedValue: 0,
+    formatted: '',
+    roundedValue: 0,
+    rounded: '',
+    roundedFormatted: '',
+    minimized: '',
+    denomination: '',
+    full: '',
+    fullPrecision: '0',
+  };
+}
+
+function optionsBlank(): FormattedNumberOptions {
+  return {
+    decimals: 0,
+    decimalsRounded: 0,
+    denomination: (v => ''),
+    roundUp: false,
+    roundDown: false,
+    positiveSign: false,
+    zeroStyled: true,
+    minimized: false,
+    blankZero: false,
+    bigUnitPostfix: false,
+  };
+}
+
+// tslint:disable-next-line: typedef
+function addBigUnitPostfix(value: BigNumber, formattedValue: string | number, removeComma: boolean = false) {
+  let postfixed;
+  if (value.gt(createBigNumber('1000000000000', 10))) {
+    postfixed = '> 1T';
+  } else if (value.gt(createBigNumber('10000000000', 10))) {
+    postfixed =
+      value.dividedBy(createBigNumber('1000000000', 10)).toFixed(0) + 'B';
+  } else if (value.gt(createBigNumber('10000000', 10))) {
+    postfixed =
+      // tslint:disable-next-line: prefer-template
+      value.dividedBy(createBigNumber('1000000', 10)).toFixed(0) + 'M';
+  } else if (value.gt(createBigNumber('10000', 10))) {
+    postfixed = value.dividedBy(createBigNumber('1000', 10)).toFixed(0) + 'K';
+  } else {
+    postfixed = addCommas(formattedValue, removeComma);
+  }
+  return postfixed;
+}
+
+export function formatNumber(
+  num: NumStrBigNumber,
+  opts: FormattedNumberOptions = optionsBlank(),
+): FormattedNumber {
+  const value = num != null ? createBigNumber(num, 10) : ZERO;
+  const { minimized, bigUnitPostfix } = opts;
+  const o: FormattedNumber = formatBlank();
+  let {
+    decimals,
+    decimalsRounded,
+    denomination,
+    roundUp,
+    roundDown,
+    positiveSign,
+    zeroStyled,
+    blankZero,
+    removeComma = false,
+  } = opts;
+
+  decimals = decimals || 0;
+  decimalsRounded = decimalsRounded || 0;
+  denomination = denomination || (_ => '');
+  positiveSign = !!positiveSign;
+  roundUp = !!roundUp;
+  roundDown = !!roundDown;
+  zeroStyled = zeroStyled;
+  blankZero = blankZero;
+
+  if (value.eq(ZERO)) {
+    if (zeroStyled) { return formatNone(); }
+    if (blankZero) { return formatBlank(); }
+  }
+
+  const decimalsValue = TEN.exponentiatedBy(decimals);
+  const decimalsRoundedValue = TEN.exponentiatedBy(decimalsRounded);
+
+  let roundingMode: BigNumber.RoundingMode;
+  if (roundDown) {
+    roundingMode = BigNumber.ROUND_DOWN;
+  } else if (roundUp) {
+    roundingMode = BigNumber.ROUND_UP;
+  } else {
+    roundingMode = BigNumber.ROUND_HALF_EVEN;
+  }
+  let formatSigFig = false;
+  if (typeof num === 'string' && isNaN(parseFloat(num))) {
+    o.value = 0;
+    o.formattedValue = 0;
+    o.formatted = '0';
+    o.roundedValue = 0;
+    o.rounded = '0';
+    o.roundedFormatted = '0';
+    o.minimized = '0';
+    o.fullPrecision = '0';
+  } else {
+    const useSignificantFiguresThreshold = TEN.exponentiatedBy(
+      new BigNumber(decimals, 10)
+        .minus(1)
+        .negated()
+        .toNumber(),
+    );
+    const roundToZeroThreshold = ZERO;
+    o.value = value.toNumber();
+    if (value.abs().lt(roundToZeroThreshold)) {
+      // value is less than zero
+      o.formattedValue = '0';
+    } else if (value.abs().lt(useSignificantFiguresThreshold)) {
+      if (!decimals) {
+        o.formattedValue = '0';
+      } else {
+        formatSigFig = true;
+        o.formattedValue = value.toPrecision(decimals, roundingMode);
+      }
+    } else {
+      o.formattedValue = value
+        .times(decimalsValue)
+        .integerValue(roundingMode)
+        .dividedBy(decimalsValue)
+        .toFixed(decimals);
+    }
+
+    const zeroFixed = ZERO.toFixed(USUAL_NUMBER_DECIMAL_PLACES);
+
+    if (bigUnitPostfix && !formatSigFig) {
+      o.formatted = addBigUnitPostfix(value, o.formattedValue, removeComma);
+    } else if (formatSigFig) {
+      // for numbers smaller than the set number of decimals - ie ones with scientific notation
+      let formatted = value.toFixed(decimals || USUAL_NUMBER_DECIMAL_PLACES);
+
+      if (formatted === zeroFixed || formatted === '-' + zeroFixed) {
+        // if this is equal to zero, try to show significant digits up to 8 digit places
+        formatted = value.toFixed(SMALLEST_NUMBER_DECIMAL_PLACES);
+        if (
+          formatted === ZERO.toFixed(SMALLEST_NUMBER_DECIMAL_PLACES) ||
+          formatted === '-' + ZERO.toFixed(SMALLEST_NUMBER_DECIMAL_PLACES)
+        ) {
+          formatted = zeroFixed; // if there are no significant digits in the 8 decimal places, just use zero
+        } else {
+          formatted = value.toFixed(
+            1 - Math.floor(Math.log(value.abs().toNumber()) / Math.log(10)),
+          ); // find first two significant digit
+        }
+      }
+      o.formatted = formatted;
+    } else {
+      o.formatted = addCommas(o.formattedValue, removeComma);
+    }
+    o.fullPrecision = value.toFixed();
+    o.roundedValue = value
+      .times(decimalsRoundedValue)
+      .integerValue(roundingMode)
+      .dividedBy(decimalsRoundedValue);
+    o.roundedFormatted = bigUnitPostfix
+      ? addBigUnitPostfix(value, o.roundedValue.toFixed(decimalsRounded), removeComma)
+      : addCommas(o.roundedValue.toFixed(decimalsRounded), removeComma);
+    // o.minimized = addCommas(encodeNumberAsBase10String(o.formattedValue), removeComma);
+    // o.rounded = encodeNumberAsBase10String(o.roundedValue);
+    // o.formattedValue = encodeNumberAsJSNumber(o.formattedValue, false);
+    o.minimized = addCommas(new BigNumber(o.formattedValue, 10).toFixed(), removeComma);
+    o.rounded = o.roundedValue.toFixed();
+    o.formattedValue = new BigNumber(o.formattedValue, 10).toNumber();
+    o.roundedValue = o.roundedValue;
+  }
+
+  if (positiveSign && !bigUnitPostfix) {
+    if (o.formattedValue || 0 >= 0) {
+      o.formatted = `+${o.formatted}`;
+      o.minimized = `+${o.minimized}`;
+    }
+    if (o.roundedValue >= 0) {
+      o.rounded = `+${o.rounded}`;
+    }
+  }
+
+  if (minimized) {
+    o.formatted = o.minimized;
+  }
+
+  o.denomination = denomination('');
+  o.full = denomination(o.formatted);
+
+  if (
+    (typeof num === 'string' && isNaN(parseFloat(num))) ||
+    o.formatted === '0'
+  ) {
+    o.formatted = ZERO.toFixed(decimalsRounded);
+  }
+  return o;
+}
+
+export const addCommas = (num: number | string, removeComma: boolean = false): string => {
+  let sides: string[] = [];
+  sides = num.toString().split('.');
+  sides[0] = removeComma ? sides[0] : sides[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return sides.join('.');
+};
+
+export function formatPercent(
+  num: NumStrBigNumber,
+  opts: FormattedNumberOptions = {},
+): FormattedNumber {
+  return formatNumber(num, {
+    decimals: 2,
+    decimalsRounded: 0,
+    denomination: (v: string) => `${v}%`,
+    positiveSign: false,
+    zeroStyled: false,
+    blankZero: false,
+    bigUnitPostfix: false,
+    ...opts,
+  });
+}
+
+export function formatEther(
+  num: NumStrBigNumber,
+  opts: FormattedNumberOptions = {},
+): FormattedNumber {
+  return formatNumber(num, {
+    decimals: ETHER_NUMBER_OF_DECIMALS,
+    decimalsRounded: ETHER_NUMBER_OF_DECIMALS,
+    denomination: v => `${v} ETH`,
+    positiveSign: false,
+    zeroStyled: false,
+    blankZero: false,
+    bigUnitPostfix: false,
+    ...opts,
+  });
+}
+
+export function formatZrx(
+  num: NumStrBigNumber,
+  opts: FormattedNumberOptions = {},
+): FormattedNumber {
+  return formatNumber(num, {
+    decimals: ZRX_NUMBER_OF_DECIMALS,
+    decimalsRounded: ZRX_NUMBER_OF_DECIMALS,
+    roundDown: true, // round down to be safe and avoid ui mismatches
+    denomination: v => `${v} ZRX`,
+    positiveSign: false,
+    zeroStyled: false,
+    blankZero: false,
+    bigUnitPostfix: false,
+    ...opts,
+  });
+}

--- a/ts/utils/format_number.ts
+++ b/ts/utils/format_number.ts
@@ -143,17 +143,17 @@ function optionsBlank(): FormattedNumberOptions {
 // tslint:disable-next-line: typedef
 function addBigUnitPostfix(value: BigNumber, formattedValue: string | number, removeComma: boolean = false) {
   let postfixed;
-  if (value.gt(createBigNumber('1000000000000', 10))) {
+  if (value.gt(createBigNumber('1e12', 10))) {
     postfixed = '> 1T';
-  } else if (value.gt(createBigNumber('10000000000', 10))) {
+  } else if (value.gt(createBigNumber('1e10', 10))) {
     postfixed =
-      value.dividedBy(createBigNumber('1000000000', 10)).toFixed(0) + 'B';
-  } else if (value.gt(createBigNumber('10000000', 10))) {
+      value.dividedBy(createBigNumber('1e9', 10)).toFixed(0) + 'B';
+  } else if (value.gt(createBigNumber('1e7', 10))) {
     postfixed =
       // tslint:disable-next-line: prefer-template
-      value.dividedBy(createBigNumber('1000000', 10)).toFixed(0) + 'M';
-  } else if (value.gt(createBigNumber('10000', 10))) {
-    postfixed = value.dividedBy(createBigNumber('1000', 10)).toFixed(0) + 'K';
+      value.dividedBy(createBigNumber('1e6', 10)).toFixed(0) + 'M';
+  } else if (value.gt(createBigNumber('1e4', 10))) {
+    postfixed = value.dividedBy(createBigNumber('1e3', 10)).toFixed(0) + 'K';
   } else {
     postfixed = addCommas(formattedValue, removeComma);
   }


### PR DESCRIPTION
This PR revamps the way we format numbers on our staking dashboard (and sets us up for a very consistent way to format numbers in the future in general). Much of this is borrowed code from the new Augur v2 codebase (MIT license) as I really like the way they do it (it is well thought out). (Our current ways in the `website` repo are fairly inconsistent and ad-hoc, this standardizes it)

Main methods are
```ts
// end user convenience functions
formatZrx(value: string | number | BigNumber, options?: FormattingOptions)
formatEther(value: string | number | BigNumber, options?: FormattingOptions)
formatPercent(value: string | number | BigNumber, options?: FormattingOptions)
// general base method, won't be used as often
formatNumber(value: string | number | BigNumber, options?: FormattingOptions) 
```

These functions return an object with multiple formatting options, which allows simple and flexible usage in our UI. 

I also wrote some unit tests.

 If/when this is approved, I will wire this up to the UI.

Let me know what you think!
