### PR TITLE
Fixing CI (issue installing yarn@1.17.0 on Circle)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
               - checkout
               - run:
                   name: install-yarn
-                  command: npm install --global yarn@1.17.0
+                  command: npm install --global --force yarn@1.17.0
               - run:
                   name: yarn
                   command: yarn --frozen-lockfile --ignore-engines install || yarn --frozen-lockfile --ignore-engines install


### PR DESCRIPTION
I would like to merge in latest `development` branch into `development-staking`, but `development` is failing from the same CI issue we fixed in `development-staking`.

Cherry-picking previous [commit](https://github.com/0xProject/website/commit/0ec11b56b98f4627a9ab5d195d930d4d80692a94) & [PR](https://github.com/0xProject/website/pull/110) from `development-staking`  and applying it to development to fix CI. 
