### PR TITLE
Fix max-width bug in safari where the window would have a very slight horizonal scroll

### DIFF
--- a/less/all.less
+++ b/less/all.less
@@ -1,3 +1,8 @@
+// Safari can overflow the width
+html, body {
+    max-width: 100%;
+}
+
 body {
     font-family: 'Roboto';
 }

--- a/less/all.less
+++ b/less/all.less
@@ -1,4 +1,4 @@
-// Safari can overflow the width
+// Safari can slightly overflow the page width without this
 html, body {
     max-width: 100%;
 }


### PR DESCRIPTION
Adding some harmless css to tame Safari. Verified in Safari, Safari iOS, and Chrome that everything looks good.