### PR TITLE
Fix horizontal overflow in safari by disabling custom scroll styles in webkit

### DIFF
--- a/less/all.less
+++ b/less/all.less
@@ -1,4 +1,3 @@
-// Safari can slightly overflow the page width without this
 html, body {
     max-width: 100%;
 }
@@ -40,16 +39,17 @@ a {
  * Adds always visible scrollbars on OSX so that user knows the content is scrollable
  * Source: https://davidwalsh.name/osx-overflow
  */
-::-webkit-scrollbar {
-    -webkit-appearance: none;
-    width: 4px;
-    height: 2px;
-}
-::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-    background-color: rgba(0, 0, 0, 0.5);
-    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
-}
+//  TODO(johnrjj) - Disabling this for now. Messes with the page width and is causing horizontal scroll problems on Safari
+// ::-webkit-scrollbar {
+//     -webkit-appearance: none;
+//     width: 4px;
+//     height: 2px;
+// }
+// ::-webkit-scrollbar-thumb {
+//     border-radius: 4px;
+//     background-color: rgba(0, 0, 0, 0.5);
+//     -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+// }
 
 // Hack: For some reason the animation applied to the material-ui textfield causes the overflow
 // applied to other elements to fail while the animation is underway. Adding this class to the


### PR DESCRIPTION
Prior PR (https://github.com/0xProject/website/pull/129) was good, did not fix the horizontal overflow issue in Safari desktop.

Turns out this is caused because of the custom styling of the scrollbar in webkit. Behavior in Safari is a bit fragile around this; Instead of messing around with calculating widths correctly, let's just disable this for now (at least until post-launch). 

This fixes the website in Safari (noticeable with the trackpad).