### PR TITLE
Adds useStakingWizard hook, refactors wizard to be router driven

### DIFF
--- a/ts/components/staking/wizard/wizard_flow.tsx
+++ b/ts/components/staking/wizard/wizard_flow.tsx
@@ -258,6 +258,7 @@ export interface StakingInputPaneProps {
     stakingPools: any;
     zrxBalance: BigNumber;
     onOpenConnectWalletDialog: () => any;
+    onGoToNextStep: () => void;
 }
 
 type AmountTrackingValue = '25%' | '50%' | '100%' | 'custom';
@@ -351,6 +352,7 @@ export const RecommendedPoolsStakeInputPane = (props: StakingInputPaneProps) => 
                 <ButtonWithIcon
                     onClick={() => {
                         setSelectedStakingPools(recommendedPools);
+                        props.onGoToNextStep();
                     }}
                     color={colors.white}
                 >
@@ -366,6 +368,7 @@ export interface MarketMakerStakeInputPaneProps {
     stakingPools: PoolWithStats[];
     zrxBalance: BigNumber;
     onOpenConnectWalletDialog: () => any;
+    onGoToNextStep: () => any;
     poolId: string;
 }
 
@@ -449,6 +452,7 @@ export const MarketMakerStakeInputPane: React.FC<MarketMakerStakeInputPaneProps>
                                 pool: marketMakerPool,
                             },
                         ]);
+                        props.onGoToNextStep();
                     }}
                     color={colors.white}
                 >
@@ -629,12 +633,21 @@ const UnlockHeader = styled(CenteredHeader)`
 export interface TokenApprovalPaneProps {
     providerState: ProviderState;
     allowance: UseAllowanceHookResult;
+    onGoToNextStep: () => void;
 }
 
 export const TokenApprovalPane = (props: TokenApprovalPaneProps) => {
-    const { providerState, allowance } = props;
+    const { providerState, allowance, onGoToNextStep } = props;
 
     const timeRemainingForAllowanceApproval = useSecondsRemaining(allowance.estimatedTransactionFinishTime);
+
+    // Simple effect that handles going to the next step when approval is done
+    // TODO(johnrjj) -- Hook up lottie animation complete to trigger next step
+    React.useLayoutEffect(() => {
+        if (allowance.loadingState && allowance.loadingState === TransactionLoadingState.Success) {
+            onGoToNextStep();
+        }
+    }, [allowance.loadingState, onGoToNextStep]);
 
     // Determine button to show based on state
     let ActiveButon = null;

--- a/ts/components/staking/wizard/wizard_info.tsx
+++ b/ts/components/staking/wizard/wizard_info.tsx
@@ -185,10 +185,11 @@ export const IntroWizardInfo: React.FC<WizardInfoProps> = ({ currentEpochStats }
 };
 
 export const ConfirmationWizardInfo: React.FC<ConfirmationWizardInfo> = ({ nextEpochStats }) => {
-    const stakingStartsEpochDate = new Date(nextEpochStats.epochStart.timestamp);
+
+    const stakingStartsEpochDate = new Date(nextEpochStats ? nextEpochStats.epochStart.timestamp : null);
     const ESTIMATED_EPOCH_LENGTH_IN_DAYS = 10;
     const firstRewardsEpochDate = addDays(
-        new Date(nextEpochStats.epochStart.timestamp),
+        stakingStartsEpochDate,
         ESTIMATED_EPOCH_LENGTH_IN_DAYS,
     );
 

--- a/ts/hooks/use_wizard.ts
+++ b/ts/hooks/use_wizard.ts
@@ -1,0 +1,85 @@
+import qs from 'query-string';
+import { useCallback, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { useQuery } from 'ts/hooks/use_query';
+
+import { WebsitePaths } from 'ts/types';
+
+// These are the three primary wizard states (controlled by routing).
+// SetupWizard handles connecting the wallet, selecting pools and staking amounts
+// ApproveTokens handles token approval
+// ReadyToStake handles the actual staking process as well as the success confirmation
+// Each of these steps can have their own internal state, which allows flexible transitions.
+export enum WizardRouterSteps {
+    SetupWizard = 'start',
+    ApproveTokens = 'approve',
+    ReadyToStake = 'stake',
+}
+
+export interface NextStepOptions {
+    replace: boolean;
+}
+
+export interface IUSeWizardResult {
+    currentStep: WizardRouterSteps;
+    next: (nextStep: WizardRouterSteps, options?: NextStepOptions) => void;
+    back: () => void;
+}
+
+const DEFAULT_STEP = WizardRouterSteps.SetupWizard;
+
+const useStakingWizard = (): IUSeWizardResult => {
+    const { step, ...restOfQueryParams } = useQuery<{
+        poolId: string | undefined;
+        step: WizardRouterSteps | undefined;
+    }>();
+    const history = useHistory();
+
+    const reset = useCallback(() => {
+        history.replace(
+            `${WebsitePaths.StakingWizard}?${qs.stringify({
+                ...restOfQueryParams,
+                step: DEFAULT_STEP,
+            })}`,
+        );
+    }, [history, restOfQueryParams]);
+
+    // Right now we just start on the 'setup' step on app mount.
+    // We currently don't support joining an in-progress stake
+    // Ensure everyone starts on the 'setup' step.
+    useEffect(() => {
+        reset();
+    // Only do this on mount (empty dep array for effect)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Right now, user-space will determine what the next step is.
+    const goToNextStep = useCallback(
+        (nextStep, { replace } = {}) => {
+            if (!nextStep) {
+                return;
+            }
+            const routingFn = replace ? history.replace : history.push;
+            return routingFn(
+                `${WebsitePaths.StakingWizard}?${qs.stringify({
+                    ...restOfQueryParams,
+                    step: nextStep,
+                })}`,
+            );
+        },
+        [history, restOfQueryParams],
+    );
+
+    const goToPreviousStep = useCallback(() => {
+        history.goBack();
+    }, [history]);
+
+    return {
+        currentStep: step || DEFAULT_STEP,
+        next: goToNextStep,
+        back: goToPreviousStep,
+    };
+};
+
+export { useStakingWizard };


### PR DESCRIPTION
This PR implements `useStakingWizard` for guiding the majority of the wizard. It is now primarily route driven  (with each primary step holding some internal state). Most things remain largely declarative (what you see is based on the route as the source of truth). This also allows us to manually move between steps (`goToNextStep`) , or do it in a declarative way. Also this gives us a back button that will naturally work with browsers (will implement in next PR) as well as sets us up nicely for animations (upcoming today hopefully!)

I'm happy to own this part while we release, should something go wrong with it -- I've kicked the tires on it for a bit and I think its fine from my own testing. Or we can revert it without much hassle if we need to.

Here's everything still working -- but note the router changing the wizard `step` query param.
![demo](https://user-images.githubusercontent.com/1103963/71987233-ac38e080-31e2-11ea-8f96-36b2332a264e.gif)
