### PR TITLE
Adds filtering to home and wizard to show only active pools

### DIFF
--- a/ts/components/staking/current_epoch_overview.tsx
+++ b/ts/components/staking/current_epoch_overview.tsx
@@ -76,7 +76,7 @@ export const CurrentEpochOverview: React.FC<CurrentEpochOverviewProps> = ({
             </OverviewItem>
             <OverviewItem>
                 <Metric>{numMarketMakers ? numMarketMakers : '-'}</Metric>
-                <Explanation>Market makers</Explanation>
+                <Explanation>Staking Pools</Explanation>
             </OverviewItem>
         </WrapperRow>
     );

--- a/ts/pages/staking/home.tsx
+++ b/ts/pages/staking/home.tsx
@@ -40,8 +40,9 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
 
     React.useEffect(() => {
         const fetchAndSetPoolsAsync = async () => {
-            const resp = await apiClient.getStakingPoolsAsync();
-            setStakingPools(resp.stakingPools);
+            const poolsResponse = await apiClient.getStakingPoolsAsync();
+            const activePools = (poolsResponse.stakingPools || []).filter(stakingUtils.isPoolActive);
+            setStakingPools(activePools);
         };
         // tslint:disable-next-line:no-floating-promises
         fetchAndSetPoolsAsync();

--- a/ts/pages/staking/wizard/wizard.tsx
+++ b/ts/pages/staking/wizard/wizard.tsx
@@ -34,6 +34,7 @@ import {
     UserStakingChoice,
 } from 'ts/types';
 import { constants } from 'ts/utils/constants';
+import { stakingUtils } from 'ts/utils/staking_utils';
 
 export interface StakingWizardProps {
     providerState: ProviderState;
@@ -79,7 +80,8 @@ export const StakingWizard: React.FC<StakingWizardProps> = props => {
         const fetchAndSetPools = async () => {
             try {
                 const poolsResponse = await apiClient.getStakingPoolsAsync();
-                setStakingPools(poolsResponse.stakingPools);
+                const activePools = (poolsResponse.stakingPools || []).filter(stakingUtils.isPoolActive);
+                setStakingPools(activePools);
             } catch (err) {
                 logUtils.warn(err);
                 setStakingPools([]);

--- a/ts/utils/staking_utils.ts
+++ b/ts/utils/staking_utils.ts
@@ -97,6 +97,6 @@ export const stakingUtils = {
     },
     // Internally we define an active pool with _some_ zrx staked for the next epoch.
     isPoolActive: (pool: PoolWithStats) => {
-        return pool.nextEpochStats.zrxStaked > 0;
+        return pool.currentEpochStats.totalProtocolFeesGeneratedInEth > 0 && pool.nextEpochStats.zrxStaked > 0;
     },
 };

--- a/ts/utils/staking_utils.ts
+++ b/ts/utils/staking_utils.ts
@@ -95,7 +95,6 @@ export const stakingUtils = {
 
         return `${name.slice(0, 37).trim()}...`;
     },
-    // Internally we define an active pool with _some_ zrx staked for the next epoch.
     isPoolActive: (pool: PoolWithStats) => {
         return pool.currentEpochStats.totalProtocolFeesGeneratedInEth > 0 && pool.nextEpochStats.zrxStaked > 0;
     },

--- a/ts/utils/staking_utils.ts
+++ b/ts/utils/staking_utils.ts
@@ -95,4 +95,8 @@ export const stakingUtils = {
 
         return `${name.slice(0, 37).trim()}...`;
     },
+    // Internally we define an active pool with _some_ zrx staked for the next epoch.
+    isPoolActive: (pool: PoolWithStats) => {
+        return pool.nextEpochStats.zrxStaked > 0;
+    },
 };


### PR DESCRIPTION
Cleans up quality of pools that users can see.

Note: if you still know the id of a pool, you can view it on the dedicated pool page, so it's not completely gone. And using that you can go stake that pool directly. But for casual users (wizard users) we want to keep the pool health to a minimum standard.