### PR TITLE
Removes token approval info pane (left side)

### DIFF
--- a/ts/components/staking/wizard/wizard_info.tsx
+++ b/ts/components/staking/wizard/wizard_info.tsx
@@ -110,49 +110,6 @@ const IntroMetric = styled.li`
     }
 `;
 
-const TokenApprovalHeader = styled.h1`
-    font-size: 36px;
-    font-weight: 300;
-    line-height: 1.1;
-    margin-bottom: 30px;
-    text-align: center;
-
-    @media (min-width: 480px) {
-        text-align: left;
-        max-width: 435px;
-    }
-
-    @media (min-width: 768px) {
-        font-size: 50px;
-    }
-`;
-
-// const TokenApprovalDescription = styled.h2`
-//     font-size: 18px;
-//     font-weight: 300;
-//     color: ${colors.textDarkSecondary};
-//     line-height: 1.44;
-//     margin-bottom: 30px;
-//     text-align: center;
-
-//     @media (min-width: 480px) {
-//         max-width: 435px;
-//         text-align: left;
-//     }
-
-//     @media (min-width: 768px) {
-//         margin-bottom: 60px;
-//     }
-// `;
-
-export const TokenApprovalInfo: React.FC<{}> = () => {
-    return (
-        <>
-            <TokenApprovalHeader>Unlock your ZRX</TokenApprovalHeader>
-        </>
-    );
-};
-
 export const IntroWizardInfo: React.FC<WizardInfoProps> = ({ currentEpochStats, allTimeStats }) => {
     return (
         <>

--- a/ts/pages/staking/wizard/wizard.tsx
+++ b/ts/pages/staking/wizard/wizard.tsx
@@ -15,7 +15,7 @@ import {
     StartStaking,
     TokenApprovalPane,
 } from 'ts/components/staking/wizard/wizard_flow';
-import { ConfirmationWizardInfo, IntroWizardInfo, TokenApprovalInfo } from 'ts/components/staking/wizard/wizard_info';
+import { ConfirmationWizardInfo, IntroWizardInfo } from 'ts/components/staking/wizard/wizard_info';
 
 import { useAllowance } from 'ts/hooks/use_allowance';
 import { useAPIClient } from 'ts/hooks/use_api_client';
@@ -154,10 +154,10 @@ export const StakingWizard: React.FC<StakingWizardProps> = props => {
                 <Splitview
                     leftComponent={
                         <>
-                            {currentStep === WizardRouterSteps.SetupWizard && (
+                            {(currentStep === WizardRouterSteps.SetupWizard ||
+                                currentStep === WizardRouterSteps.ApproveTokens) && (
                                 <IntroWizardInfo currentEpochStats={currentEpochStats} allTimeStats={allTimeStats} />
                             )}
-                            {currentStep === WizardRouterSteps.ApproveTokens && <TokenApprovalInfo />}
                             {currentStep === WizardRouterSteps.ReadyToStake && (
                                 <ConfirmationWizardInfo nextEpochStats={nextEpochStats} />
                             )}


### PR DESCRIPTION
Too noisy, let's remove and just use the previous step info pane.