### PR TITLE
Grab current epoch rewards from api instead of with web3

### DIFF
--- a/ts/components/staking/current_epoch_overview.tsx
+++ b/ts/components/staking/current_epoch_overview.tsx
@@ -1,4 +1,3 @@
-import { BigNumber } from '@0x/utils';
 import { differenceInCalendarDays } from 'date-fns';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -9,7 +8,7 @@ import { formatEther, formatZrx } from 'ts/utils/format_number';
 
 interface CurrentEpochOverviewProps {
     currentEpochEndDate?: Date;
-    currentEpochRewards?: BigNumber;
+    currentEpochRewards?: number;
     numMarketMakers?: number;
     zrxStaked?: number;
 }

--- a/ts/hooks/use_stake.ts
+++ b/ts/hooks/use_stake.ts
@@ -1,5 +1,5 @@
 import { ChainId, ContractAddresses, getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
-import { StakingContract, StakingProxyContract, WETH9Contract } from '@0x/contract-wrappers';
+import { StakingContract, StakingProxyContract } from '@0x/contract-wrappers';
 import { BigNumber, logUtils } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { addMilliseconds } from 'date-fns';
@@ -26,18 +26,6 @@ const normalizeStakePoolData = (stakePoolData: StakePoolData[]) =>
         amountBaseUnits: toZrxBaseUnits(pool.zrxAmount),
     }));
 
-const toAggregatedStats = (stats: BigNumber[]) => {
-    const [rewardsAvailable, numPoolsToFinalize, totalFeesCollected, totalWeightedStake, totalRewardsFinalized] = stats;
-
-    return {
-        rewardsAvailable,
-        numPoolsToFinalize,
-        totalFeesCollected,
-        totalWeightedStake,
-        totalRewardsFinalized,
-    };
-};
-
 export interface UseStakeHookResult {
     depositAndStake: (stakingPools: StakePoolData[], callback?: () => void) => void;
     unstake: (stakePoolData: StakePoolData[], callback?: () => void) => void;
@@ -49,7 +37,6 @@ export interface UseStakeHookResult {
     result?: TransactionReceiptWithDecodedLogs;
     estimatedTimeMs?: number;
     estimatedTransactionFinishTime?: Date;
-    currentEpochRewards?: BigNumber;
 }
 
 export const useStake = (networkId: ChainId, providerState: ProviderState): UseStakeHookResult => {
@@ -58,7 +45,6 @@ export const useStake = (networkId: ChainId, providerState: ProviderState): UseS
     const [result, setResult] = useState<TransactionReceiptWithDecodedLogs | undefined>(undefined);
     const [estimatedTimeMs, setEstimatedTimeMs] = useState<number | undefined>(undefined);
     const [estimatedTransactionFinishTime, setEstimatedTransactionFinishTime] = useState<Date | undefined>(undefined);
-    const [currentEpochRewards, setCurrentEpochRewards] = useState<BigNumber | undefined>(undefined);
 
     const [ownerAddress, setOwnerAddress] = useState<string | undefined>(undefined);
     const [stakingContract, setStakingContract] = useState<StakingContract>(undefined);
@@ -221,47 +207,10 @@ export const useStake = (networkId: ChainId, providerState: ProviderState): UseS
     }, [estimatedTimeMs]);
 
     useEffect(() => {
-        // If we already have computed rewards or are missing some dependencies we should bail out
-        if (currentEpochRewards || !contractAddresses || !providerState || !stakingContract) {
+        if (!contractAddresses || !providerState || !stakingContract) {
             return;
         }
-
-        const getCurrentEpochRewards = async () => {
-            const { web3Wrapper } = providerState;
-
-            const stakingProxyAddress = contractAddresses.stakingProxy;
-            const wethContractAddress = await stakingContract.getWethContract().callAsync();
-            const wethContract = new WETH9Contract(wethContractAddress, providerState.provider);
-
-            const [ethBalanceInWei, wethBalanceInWei, currentEpoch, wethReservedForPoolRewards] = await Promise.all([
-                web3Wrapper.getBalanceInWeiAsync(stakingProxyAddress),
-                wethContract.balanceOf(stakingProxyAddress).callAsync(),
-                stakingContract.currentEpoch().callAsync(),
-                stakingContract.wethReservedForPoolRewards().callAsync(),
-            ]);
-
-            const prevEpoch = currentEpoch.minus(1);
-            const { rewardsAvailable, totalRewardsFinalized } = await stakingProxyContract
-                .aggregatedStatsByEpoch(prevEpoch)
-                .callAsync()
-                .then(toAggregatedStats);
-
-            const totalBalanceInWei = ethBalanceInWei.plus(wethBalanceInWei);
-            const prevEpochRollover = rewardsAvailable.minus(totalRewardsFinalized).plus(wethReservedForPoolRewards);
-            const _currentEpochRewards = Web3Wrapper.toUnitAmount(
-                totalBalanceInWei.minus(prevEpochRollover),
-                constants.DECIMAL_PLACES_ETH,
-            );
-
-            setCurrentEpochRewards(_currentEpochRewards);
-        };
-
-        getCurrentEpochRewards().catch((err: Error) => {
-            setCurrentEpochRewards(undefined);
-            logUtils.warn(err);
-            errorReporter.report(err);
-        });
-    }, [contractAddresses, currentEpochRewards, providerState, stakingContract, stakingProxyContract]);
+    }, [contractAddresses, providerState, stakingContract, stakingProxyContract]);
 
     return {
         loadingState,
@@ -269,7 +218,6 @@ export const useStake = (networkId: ChainId, providerState: ProviderState): UseS
         error,
         estimatedTimeMs,
         stakingContract,
-        currentEpochRewards,
         depositAndStake: (stakePoolData: StakePoolData[], callback?: () => void) => {
             depositAndStakeAsync(stakePoolData)
                 .then(() => {

--- a/ts/pages/staking/home.tsx
+++ b/ts/pages/staking/home.tsx
@@ -18,7 +18,6 @@ import { StakingPoolDetailRow } from 'ts/components/staking/staking_pool_detail_
 import { StakingHero } from 'ts/components/staking/hero';
 import { Heading } from 'ts/components/text';
 import { useAPIClient } from 'ts/hooks/use_api_client';
-import { useStake } from 'ts/hooks/use_stake';
 import { errorReporter } from 'ts/utils/error_reporter';
 import { stakingUtils } from 'ts/utils/staking_utils';
 
@@ -32,12 +31,11 @@ export interface StakingIndexProps {}
 export const StakingIndex: React.FC<StakingIndexProps> = () => {
     const [stakingPools, setStakingPools] = React.useState<PoolWithStats[] | undefined>(undefined);
     const networkId = useSelector((state: State) => state.networkId);
-    const providerState = useSelector((state: State) => state.providerState);
 
     const apiClient = useAPIClient(networkId);
-    const { currentEpochRewards } = useStake(networkId, providerState);
 
     const [nextEpochStats, setNextEpochStats] = React.useState<Epoch | undefined>(undefined);
+    const [currentEpochStats, setCurrentEpochStats] = React.useState<Epoch | undefined>(undefined);
 
     React.useEffect(() => {
         const fetchAndSetPoolsAsync = async () => {
@@ -61,9 +59,11 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
         const fetchAndSetEpochs = async () => {
             try {
                 const epochsResponse = await apiClient.getStakingEpochsAsync();
+                setCurrentEpochStats(epochsResponse.currentEpoch);
                 setNextEpochStats(epochsResponse.nextEpoch);
             } catch (err) {
                 logUtils.warn(err);
+                setCurrentEpochStats(undefined);
                 setNextEpochStats(undefined);
                 errorReporter.report(err);
             }
@@ -104,7 +104,7 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
                 <CurrentEpochOverview
                     zrxStaked={nextEpochStats && nextEpochStats.zrxStaked}
                     currentEpochEndDate={currentEpochEndDate}
-                    currentEpochRewards={currentEpochRewards}
+                    currentEpochRewards={currentEpochStats && currentEpochStats.protocolFeesGeneratedInEth}
                     numMarketMakers={stakingPools && stakingPools.length}
                 />
             </SectionWrapper>


### PR DESCRIPTION
This is kinda 🤦‍♂ We had the correct value available in the api under a different name, so there is no point in fetching this from the smart contract.