### PR TITLE
Use new website-backend url for production

### DIFF
--- a/ts/utils/configs.ts
+++ b/ts/utils/configs.ts
@@ -5,7 +5,7 @@ const INFURA_API_KEY = 'T5WSC8cautR4KXyYgsRs';
 
 export const configs = {
     AMOUNT_DISPLAY_PRECSION: 5,
-    BACKEND_BASE_PROD_URL: 'https://website-api.0x.org',
+    BACKEND_BASE_PROD_URL: 'https://website.api.0x.org',
     BACKEND_BASE_STAGING_URL: 'https://staging-website-api.0x.org',
     BACKEND_BASE_DEV_URL: 'https://localhost:3001',
     API_BASE_PROD_URL: 'https://api.0x.org',


### PR DESCRIPTION
We migrated `website-backend` to run on our Kubernetes cluster due to some deployment blocking issues with the old environment. The url has changed to: `https://website.api.0x.org` now

Will ninja this cause and follow up on any feedback