### PR TITLE
Increase granularity on time to epoch end on staking home

### DIFF
--- a/ts/components/staking/current_epoch_overview.tsx
+++ b/ts/components/staking/current_epoch_overview.tsx
@@ -1,4 +1,4 @@
-import { differenceInCalendarDays } from 'date-fns';
+import { formatDistanceStrict, isPast } from 'date-fns';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -56,13 +56,21 @@ const Explanation = styled(Text).attrs({
     width: '100%',
 })``;
 
+const timeToEpochEnd = (currentEpochEndDate?: Date): string => {
+    if (!currentEpochEndDate || isPast(currentEpochEndDate)) {
+        return '-';
+    }
+
+    const now = new Date();
+    return formatDistanceStrict(currentEpochEndDate, now, { roundingMethod: 'ceil' });
+};
+
 export const CurrentEpochOverview: React.FC<CurrentEpochOverviewProps> = ({
     currentEpochEndDate,
     currentEpochRewards,
     numMarketMakers,
     zrxStaked,
 }) => {
-    const now = new Date();
     return (
         <WrapperRow>
             <OverviewItem>
@@ -70,11 +78,7 @@ export const CurrentEpochOverview: React.FC<CurrentEpochOverviewProps> = ({
                 <Explanation>ZRX Staked</Explanation>
             </OverviewItem>
             <OverviewItem>
-                <Metric>
-                    {currentEpochEndDate
-                        ? `${Math.max(differenceInCalendarDays(currentEpochEndDate, now), 0)} days`
-                        : '-'}
-                </Metric>
+                <Metric>{timeToEpochEnd(currentEpochEndDate)}</Metric>
                 <Explanation>Epoch ends</Explanation>
             </OverviewItem>
             <OverviewItem>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5450545/72531955-d0e02880-3872-11ea-8e2e-6521e7ec4de5.png)

Quick fix per internal request, would be cool to make this interactively count down in the future but I think this is better than what we have now.