### PR TITLE
Staking home pools sorting

### DIFF
--- a/ts/components/button.tsx
+++ b/ts/components/button.tsx
@@ -51,7 +51,13 @@ export const Button: React.StatelessComponent<ButtonInterface> = (props: ButtonI
     }
 
     const Component = linkElem ? ButtonBase.withComponent<any>(linkElem) : ButtonBase;
-    const targetProp = href && target ? { target } : {};
+    const targetProp: { target?: string; rel?: string } = href && target ? { target } : {};
+
+    // NOTE: See https://developers.google.com/web/tools/lighthouse/audits/noopener
+    if (targetProp.target === '_blank') {
+        targetProp.rel = 'noopener';
+    }
+
     const buttonProps = isButton ? { disabled: isDisabled } : {};
 
     return (

--- a/ts/components/staking/dashboard_hero.tsx
+++ b/ts/components/staking/dashboard_hero.tsx
@@ -255,15 +255,17 @@ export const DashboardHero: React.FC<DashboardHeroProps> = ({
                         </Title>
                         <HorizontalList>
                             <li>{utils.getAddressBeginAndEnd(operatorAddress)}</li>
-                            {websiteUrl && <li>{websiteUrl}</li>}
-                            <li>
-                                <a href="">{formatPercent(rewardsShared).minimized}% Rewards Shared</a>
-                            </li>
+                            {websiteUrl && (
+                                <li>
+                                    <a href={websiteUrl} target="_blank" rel="noopener">
+                                        {websiteUrl}
+                                    </a>
+                                </li>
+                            )}
+                            <li>{formatPercent(rewardsShared).minimized}% Rewards Shared</li>
                             {isVerified && (
                                 <VerificationIndicator>
-                                    <a href="">
-                                        <Checkmark /> Verified identity
-                                    </a>
+                                    <Checkmark /> Verified identity
                                 </VerificationIndicator>
                             )}
                         </HorizontalList>

--- a/ts/components/staking/pools_list_sorting_selector.tsx
+++ b/ts/components/staking/pools_list_sorting_selector.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { PoolsListSortingParameter } from 'ts/types';
+
+interface PoolsListSortingSelectorProps {
+    setPoolSortingParam: (sortingParam: PoolsListSortingParameter) => void;
+}
+export const PoolsListSortingSelector: React.FC<PoolsListSortingSelectorProps> = ({ setPoolSortingParam }) => {
+    return (
+        <select
+            onChange={e => {
+                const selected = e.target.value as PoolsListSortingParameter;
+                setPoolSortingParam(selected);
+            }}
+        >
+            <option value={PoolsListSortingParameter.Staked}>Staked</option>
+            <option value={PoolsListSortingParameter.RewardsShared}>RewardsShared</option>
+            <option value={PoolsListSortingParameter.ProtocolFees} selected>
+                ProtocolFees
+            </option>
+        </select>
+    );
+};

--- a/ts/components/staking/pools_list_sorting_selector.tsx
+++ b/ts/components/staking/pools_list_sorting_selector.tsx
@@ -8,10 +8,11 @@ import { colors } from 'ts/style/colors';
 import { PoolsListSortingParameter } from 'ts/types';
 
 const Wrapper = styled.div`
-    width: 450px;
+    @media (min-width: 768px) {
+        width: 450px;
+    }
 `;
 
-// TODO: align arrow properly
 const Arrow = ({ isExpanded }: { isExpanded?: boolean }) => (
     <svg
         style={{ transform: isExpanded ? 'rotate(180deg)' : null }}
@@ -33,12 +34,23 @@ const ExpandedMenu = styled.div`
     flex-direction: column;
     width: 450px;
     padding: 30px;
+
+    @media (max-width: 768px) {
+        width: 100%;
+        left: 0;
+    }
 `;
 
 const ToggleRow = styled.div`
-    text-align: right;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
     user-select: none;
     cursor: pointer;
+
+    * + * {
+        margin-left: 8px;
+    }
 `;
 
 const MenuItem = styled.div`
@@ -49,20 +61,26 @@ const MenuItem = styled.div`
     }
 `;
 
-const StyledText = styled(Text).attrs({
-    fontFamily: 'Formular',
-    fontSize: '20px',
-})`
+const StyledText = styled(Text)`
+    font-family: 'Formular', monospace;
+    font-size: 20px;
     font-feature-settings: 'tnum' on, 'lnum' on;
+
+    @media (max-width: 768px) {
+        font-size: 18px;
+    }
 `;
 
-const StyledParagraph = styled(Text).attrs({
-    fontFamily: 'Formular',
-    fontSize: '17px',
-    fontColor: 'rgba(0,0,0,0.7)',
-    fontWeight: 300,
-})`
-    max-width: 350px;
+const StyledDescription = styled(Text)`
+    font-family: 'Formular', monospace;
+    color: rgba(0, 0, 0, 0.7);
+    font-weight: 300;
+    font-size: 14px;
+
+    @media (min-width: 768px) {
+        font-size: 17px;
+        max-width: 350px;
+    }
 `;
 
 const sortingParamMapping = {
@@ -83,31 +101,29 @@ export const PoolsListSortingSelector: React.FC<PoolsListSortingSelectorProps> =
     return (
         <Wrapper onClick={() => setIsExpanded(_isExpanded => !_isExpanded)}>
             <ToggleRow>
-                <StyledText Tag="span">Sort by </StyledText>
-                <StyledText Tag="span" fontColor={colors.textDarkSecondary}>
-                    {sortingParamMapping[currentSortingParam]}{' '}
-                </StyledText>
+                <StyledText>Sort by</StyledText>
+                <StyledText fontColor={colors.textDarkSecondary}>{sortingParamMapping[currentSortingParam]}</StyledText>
                 <Arrow isExpanded={isExpanded} />
             </ToggleRow>
             {isExpanded && (
                 <ExpandedMenu>
                     <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.Staked)}>
                         <StyledText>{sortingParamMapping[PoolsListSortingParameter.Staked]}</StyledText>
-                        <StyledParagraph>
+                        <StyledDescription>
                             An approximation for how fully staked the pool is for the upcoming epoch
-                        </StyledParagraph>
+                        </StyledDescription>
                     </MenuItem>
                     <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.RewardsShared)}>
                         <StyledText>{sortingParamMapping[PoolsListSortingParameter.RewardsShared]}</StyledText>
-                        <StyledParagraph>
+                        <StyledDescription>
                             An approximation for how fully staked the pool is for the upcoming epoch
-                        </StyledParagraph>
+                        </StyledDescription>
                     </MenuItem>
                     <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.ProtocolFees)}>
                         <StyledText>{sortingParamMapping[PoolsListSortingParameter.ProtocolFees]}</StyledText>
-                        <StyledParagraph>
+                        <StyledDescription>
                             An approximation for how fully staked the pool is for the upcoming epoch
-                        </StyledParagraph>
+                        </StyledDescription>
                     </MenuItem>
                 </ExpandedMenu>
             )}

--- a/ts/components/staking/pools_list_sorting_selector.tsx
+++ b/ts/components/staking/pools_list_sorting_selector.tsx
@@ -30,7 +30,9 @@ const ExpandedMenu = styled.div`
     border: 1px solid rgba(92, 92, 92, 0.15);
     position: absolute;
     display: flex;
+    flex-direction: column;
     width: 450px;
+    padding: 30px;
 `;
 
 const ToggleRow = styled.div`
@@ -39,12 +41,35 @@ const ToggleRow = styled.div`
     cursor: pointer;
 `;
 
-const MenuItem = styled.div``;
+const MenuItem = styled.div`
+    cursor: pointer;
+
+    & + & {
+        margin-top: 30px;
+    }
+`;
 
 const StyledText = styled(Text).attrs({
     fontFamily: 'Formular',
     fontSize: '20px',
-})``;
+})`
+    font-feature-settings: 'tnum' on, 'lnum' on;
+`;
+
+const StyledParagraph = styled(Text).attrs({
+    fontFamily: 'Formular',
+    fontSize: '17px',
+    fontColor: 'rgba(0,0,0,0.7)',
+    fontWeight: 300,
+})`
+    max-width: 350px;
+`;
+
+const sortingParamMapping = {
+    [PoolsListSortingParameter.Staked]: 'Staked',
+    [PoolsListSortingParameter.RewardsShared]: 'Rewards Shared',
+    [PoolsListSortingParameter.ProtocolFees]: 'Fees Generated',
+};
 
 interface PoolsListSortingSelectorProps {
     setPoolSortingParam: (sortingParam: PoolsListSortingParameter) => void;
@@ -60,14 +85,29 @@ export const PoolsListSortingSelector: React.FC<PoolsListSortingSelectorProps> =
             <ToggleRow>
                 <StyledText Tag="span">Sort by </StyledText>
                 <StyledText Tag="span" fontColor={colors.textDarkSecondary}>
-                    {currentSortingParam}{' '}
+                    {sortingParamMapping[currentSortingParam]}{' '}
                 </StyledText>
                 <Arrow isExpanded={isExpanded} />
             </ToggleRow>
             {isExpanded && (
                 <ExpandedMenu>
-                    <MenuItem>
-                        <span>hello world</span>
+                    <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.Staked)}>
+                        <StyledText>{sortingParamMapping[PoolsListSortingParameter.Staked]}</StyledText>
+                        <StyledParagraph>
+                            An approximation for how fully staked the pool is for the upcoming epoch
+                        </StyledParagraph>
+                    </MenuItem>
+                    <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.RewardsShared)}>
+                        <StyledText>{sortingParamMapping[PoolsListSortingParameter.RewardsShared]}</StyledText>
+                        <StyledParagraph>
+                            An approximation for how fully staked the pool is for the upcoming epoch
+                        </StyledParagraph>
+                    </MenuItem>
+                    <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.ProtocolFees)}>
+                        <StyledText>{sortingParamMapping[PoolsListSortingParameter.ProtocolFees]}</StyledText>
+                        <StyledParagraph>
+                            An approximation for how fully staked the pool is for the upcoming epoch
+                        </StyledParagraph>
                     </MenuItem>
                 </ExpandedMenu>
             )}

--- a/ts/components/staking/pools_list_sorting_selector.tsx
+++ b/ts/components/staking/pools_list_sorting_selector.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { MouseEvent, useState } from 'react';
 import styled from 'styled-components';
 
+import { Button } from 'ts/components/button';
 import { Text } from 'ts/components/ui/text';
 
 import { colors } from 'ts/style/colors';
+import { constants } from 'ts/utils/constants';
 
 import { PoolsListSortingParameter } from 'ts/types';
 
@@ -83,6 +85,17 @@ const StyledDescription = styled(Text)`
     }
 `;
 
+const StyledButton = styled(Button)`
+    /* Override default button styles */
+    && {
+        font-size: 14px;
+
+        @media (min-width: 768px) {
+            font-size: 17px;
+        }
+    }
+`;
+
 const sortingParamMapping = {
     [PoolsListSortingParameter.Staked]: 'Staked',
     [PoolsListSortingParameter.RewardsShared]: 'Rewards Shared',
@@ -110,19 +123,58 @@ export const PoolsListSortingSelector: React.FC<PoolsListSortingSelectorProps> =
                     <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.Staked)}>
                         <StyledText>{sortingParamMapping[PoolsListSortingParameter.Staked]}</StyledText>
                         <StyledDescription>
-                            An approximation for how fully staked the pool is for the upcoming epoch
+                            An approximation for how fully stake the pool is for current epoch.{' '}
+                            <StyledButton
+                                target="_blank"
+                                href={`${constants.STAKING_FAQ_DOCS}#what-is-the-stake--or-stake-ratio`}
+                                isInline={true}
+                                isTransparent={true}
+                                isNoBorder={true}
+                                isNoPadding={true}
+                                onClick={(e: MouseEvent<HTMLElement>) => {
+                                    e.stopPropagation();
+                                }}
+                            >
+                                Learn more
+                            </StyledButton>
                         </StyledDescription>
                     </MenuItem>
                     <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.RewardsShared)}>
                         <StyledText>{sortingParamMapping[PoolsListSortingParameter.RewardsShared]}</StyledText>
                         <StyledDescription>
-                            An approximation for how fully staked the pool is for the upcoming epoch
+                            The percent of rewards the pool is sharing with stakers.{' '}
+                            <StyledButton
+                                target="_blank"
+                                href={`${constants.STAKING_FAQ_DOCS}#what-are-rewards-shared`}
+                                isInline={true}
+                                isTransparent={true}
+                                isNoBorder={true}
+                                isNoPadding={true}
+                                onClick={(e: MouseEvent<HTMLElement>) => {
+                                    e.stopPropagation();
+                                }}
+                            >
+                                Learn more
+                            </StyledButton>
                         </StyledDescription>
                     </MenuItem>
                     <MenuItem onClick={() => setPoolSortingParam(PoolsListSortingParameter.ProtocolFees)}>
                         <StyledText>{sortingParamMapping[PoolsListSortingParameter.ProtocolFees]}</StyledText>
                         <StyledDescription>
-                            An approximation for how fully staked the pool is for the upcoming epoch
+                            The fees the pool has collected in the current epoch.{' '}
+                            <StyledButton
+                                target="_blank"
+                                href={`${constants.STAKING_FAQ_DOCS}#what-are-collected-fees`}
+                                isInline={true}
+                                isTransparent={true}
+                                isNoBorder={true}
+                                isNoPadding={true}
+                                onClick={(e: MouseEvent<HTMLElement>) => {
+                                    e.stopPropagation();
+                                }}
+                            >
+                                Learn more
+                            </StyledButton>
                         </StyledDescription>
                     </MenuItem>
                 </ExpandedMenu>

--- a/ts/components/staking/pools_list_sorting_selector.tsx
+++ b/ts/components/staking/pools_list_sorting_selector.tsx
@@ -1,23 +1,76 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import { Text } from 'ts/components/ui/text';
+
+import { colors } from 'ts/style/colors';
 
 import { PoolsListSortingParameter } from 'ts/types';
 
+const Wrapper = styled.div`
+    width: 450px;
+`;
+
+// TODO: align arrow properly
+const Arrow = ({ isExpanded }: { isExpanded?: boolean }) => (
+    <svg
+        style={{ transform: isExpanded ? 'rotate(180deg)' : null }}
+        width="13"
+        height="6"
+        viewBox="0 0 13 6"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path d="M1 1L6.5 5L12 1" stroke="black" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+);
+
+const ExpandedMenu = styled.div`
+    background: ${colors.backgroundLightGrey};
+    border: 1px solid rgba(92, 92, 92, 0.15);
+    position: absolute;
+    display: flex;
+    width: 450px;
+`;
+
+const ToggleRow = styled.div`
+    text-align: right;
+    user-select: none;
+    cursor: pointer;
+`;
+
+const MenuItem = styled.div``;
+
+const StyledText = styled(Text).attrs({
+    fontFamily: 'Formular',
+    fontSize: '20px',
+})``;
+
 interface PoolsListSortingSelectorProps {
     setPoolSortingParam: (sortingParam: PoolsListSortingParameter) => void;
+    currentSortingParam: PoolsListSortingParameter;
 }
-export const PoolsListSortingSelector: React.FC<PoolsListSortingSelectorProps> = ({ setPoolSortingParam }) => {
+export const PoolsListSortingSelector: React.FC<PoolsListSortingSelectorProps> = ({
+    setPoolSortingParam,
+    currentSortingParam,
+}) => {
+    const [isExpanded, setIsExpanded] = useState<boolean>(false);
     return (
-        <select
-            onChange={e => {
-                const selected = e.target.value as PoolsListSortingParameter;
-                setPoolSortingParam(selected);
-            }}
-        >
-            <option value={PoolsListSortingParameter.Staked}>Staked</option>
-            <option value={PoolsListSortingParameter.RewardsShared}>RewardsShared</option>
-            <option value={PoolsListSortingParameter.ProtocolFees} selected>
-                ProtocolFees
-            </option>
-        </select>
+        <Wrapper onClick={() => setIsExpanded(_isExpanded => !_isExpanded)}>
+            <ToggleRow>
+                <StyledText Tag="span">Sort by </StyledText>
+                <StyledText Tag="span" fontColor={colors.textDarkSecondary}>
+                    {currentSortingParam}{' '}
+                </StyledText>
+                <Arrow isExpanded={isExpanded} />
+            </ToggleRow>
+            {isExpanded && (
+                <ExpandedMenu>
+                    <MenuItem>
+                        <span>hello world</span>
+                    </MenuItem>
+                </ExpandedMenu>
+            )}
+        </Wrapper>
     );
 };

--- a/ts/components/staking/staking_pool_detail_row.tsx
+++ b/ts/components/staking/staking_pool_detail_row.tsx
@@ -78,7 +78,7 @@ export const StakingPoolDetailRow: React.FC<IStakingPoolDetailRowProps> = ({
         </PoolOverviewSection>
         <PoolPerformanceSection>
             <PoolPerformanceItem>
-                <span>Collected Fees</span>
+                <span>Fees generated</span>
                 <span>{formatEther(totalFeesGeneratedInEth || 0).formatted} ETH</span>
             </PoolPerformanceItem>
             <PoolPerformanceItem>

--- a/ts/components/staking/wizard/market_maker.tsx
+++ b/ts/components/staking/wizard/market_maker.tsx
@@ -178,7 +178,7 @@ export const MarketMaker: React.FC<MarketMakerProps> = props => {
             </Heading>
             <Metrics>
                 <Metric>
-                    <MetricTitle>Collected fees</MetricTitle>
+                    <MetricTitle>Fees generated</MetricTitle>
                     <MetricAmount>{formatEther(collectedFees).formatted} ETH</MetricAmount>
                     <StyledInfoTooltip id="fees">
                         The fees the pool has collected in the current epoch

--- a/ts/components/ui/unlock_icon.tsx
+++ b/ts/components/ui/unlock_icon.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 const UnlockIcon = () => {
     return (
         <svg width="86" height="72" viewBox="0 0 86 72" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect width="35" height="35" rx="17.5" transform="matrix(-1 0 0 1 36 1)" stroke="#00AE99" stroke-width="2"/>
-            <rect width="83.3824" height="35" rx="17.5" transform="matrix(-1 0 0 1 84.3823 1)" stroke="#00AE99" stroke-width="2"/>
-            <rect x="49.3823" y="36" width="35" height="35" rx="17.5" stroke="#00AE99" stroke-width="2"/>
-            <rect x="1" y="36" width="83.3824" height="35" rx="17.5" stroke="#00AE99" stroke-width="2"/>
+            <rect width="35" height="35" rx="17.5" transform="matrix(-1 0 0 1 36 1)" stroke="#00AE99" strokeWidth="2"/>
+            <rect width="83.3824" height="35" rx="17.5" transform="matrix(-1 0 0 1 84.3823 1)" stroke="#00AE99" strokeWidth="2"/>
+            <rect x="49.3823" y="36" width="35" height="35" rx="17.5" stroke="#00AE99" strokeWidth="2"/>
+            <rect x="1" y="36" width="83.3824" height="35" rx="17.5" stroke="#00AE99" strokeWidth="2"/>
         </svg>
     );
 };

--- a/ts/pages/staking/home.tsx
+++ b/ts/pages/staking/home.tsx
@@ -51,6 +51,11 @@ const HeadingRow = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
+
+    @media (max-width: 768px) {
+        flex-direction: column;
+        align-items: start;
+    }
 `;
 
 export interface StakingIndexProps {}

--- a/ts/pages/staking/home.tsx
+++ b/ts/pages/staking/home.tsx
@@ -153,7 +153,10 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
                     <Heading asElement="h3" fontWeight="400" isNoMargin={true}>
                         Staking Pools
                     </Heading>
-                    <PoolsListSortingSelector setPoolSortingParam={setPoolSortingParam} />
+                    <PoolsListSortingSelector
+                        setPoolSortingParam={setPoolSortingParam}
+                        currentSortingParam={poolSortingParam}
+                    />
                 </HeadingRow>
                 {sortedStakingPools &&
                     sortedStakingPools.map(pool => {

--- a/ts/pages/staking/home.tsx
+++ b/ts/pages/staking/home.tsx
@@ -13,6 +13,7 @@ import { CFLMetrics } from 'ts/pages/cfl/cfl_metrics';
 
 import { CurrentEpochOverview } from 'ts/components/staking/current_epoch_overview';
 import { StakingPageLayout } from 'ts/components/staking/layout/staking_page_layout';
+import { PoolsListSortingSelector } from 'ts/components/staking/pools_list_sorting_selector';
 import { StakingPoolDetailRow } from 'ts/components/staking/staking_pool_detail_row';
 
 import { useStake } from 'ts/hooks/use_stake';
@@ -24,7 +25,7 @@ import { constants } from 'ts/utils/constants';
 import { errorReporter } from 'ts/utils/error_reporter';
 import { stakingUtils } from 'ts/utils/staking_utils';
 
-import { Epoch, PoolWithStats, ScreenWidths, WebsitePaths } from 'ts/types';
+import { Epoch, PoolsListSortingParameter, PoolWithStats, ScreenWidths, WebsitePaths } from 'ts/types';
 
 const sortByStaked = (a: PoolWithStats, b: PoolWithStats): number =>
     b.nextEpochStats.approximateStakeRatio - a.nextEpochStats.approximateStakeRatio;
@@ -40,40 +41,17 @@ const sortByRewardsShared = (a: PoolWithStats, b: PoolWithStats): number => {
     return bRewardsShared - aRewardsShared;
 };
 
-enum SortingParameter {
-    Staked = 'staked',
-    ProtocolFees = 'protocolFees',
-    RewardsShared = 'rewardsShared',
-}
-
 const sortFnMapping: { [key: string]: (a: PoolWithStats, b: PoolWithStats) => number } = {
-    [SortingParameter.Staked]: sortByStaked,
-    [SortingParameter.ProtocolFees]: sortByProtocolFeesDesc,
-    [SortingParameter.RewardsShared]: sortByRewardsShared,
+    [PoolsListSortingParameter.Staked]: sortByStaked,
+    [PoolsListSortingParameter.ProtocolFees]: sortByProtocolFeesDesc,
+    [PoolsListSortingParameter.RewardsShared]: sortByRewardsShared,
 };
 
-interface PoolsHeaderProps {
-    setPoolSortingParam: (sortingParam: SortingParameter) => undefined;
-}
-const PoolsHeader: React.FC<PoolsHeaderProps> = ({ setPoolSortingParam }) => {
-    return (
-        <>
-            <Heading asElement="h3" fontWeight="400" isNoMargin={true}>
-                Staking Pools
-            </Heading>
-            <select
-                onChange={e => {
-                    const selected = e.target.value as SortingParameter;
-                    setPoolSortingParam(selected);
-                }}
-            >
-                <option value={SortingParameter.Staked}>Staked</option>
-                <option value={SortingParameter.RewardsShared}>RewardsShared</option>
-                <option value={SortingParameter.ProtocolFees}>ProtocolFees</option>
-            </select>
-        </>
-    );
-};
+const HeadingRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+`;
 
 export interface StakingIndexProps {}
 export const StakingIndex: React.FC<StakingIndexProps> = () => {
@@ -84,7 +62,9 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
     const { currentEpochRewards } = useStake(networkId, providerState);
     const [nextEpochStats, setNextEpochStats] = React.useState<Epoch | undefined>(undefined);
 
-    const [poolSortingParam, setPoolSortingParam] = React.useState<SortingParameter>(SortingParameter.ProtocolFees);
+    const [poolSortingParam, setPoolSortingParam] = React.useState<PoolsListSortingParameter>(
+        PoolsListSortingParameter.ProtocolFees,
+    );
 
     React.useEffect(() => {
         const fetchAndSetPoolsAsync = async () => {
@@ -169,7 +149,12 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
                 />
             </SectionWrapper>
             <SectionWrapper>
-                <PoolsHeader setPoolSortingParam={setPoolSortingParam} />
+                <HeadingRow>
+                    <Heading asElement="h3" fontWeight="400" isNoMargin={true}>
+                        Staking Pools
+                    </Heading>
+                    <PoolsListSortingSelector setPoolSortingParam={setPoolSortingParam} />
+                </HeadingRow>
                 {sortedStakingPools &&
                     sortedStakingPools.map(pool => {
                         return (

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -4,6 +4,12 @@ import { Web3Wrapper } from '@0x/web3-wrapper';
 import { Provider, SupportedProvider, ZeroExProvider } from 'ethereum-types';
 import * as React from 'react';
 
+export enum PoolsListSortingParameter {
+    Staked = 'staked',
+    ProtocolFees = 'protocolFees',
+    RewardsShared = 'rewardsShared',
+}
+
 export interface MailchimpSubscriberInfo {
     FNAME?: string;
     LNAME?: string;


### PR DESCRIPTION
**Desktop**
![image](https://user-images.githubusercontent.com/5450545/72910619-143a0b80-3d39-11ea-886e-4025b069a9d1.png)

**Mobile**
![image](https://user-images.githubusercontent.com/5450545/72910699-30d64380-3d39-11ea-99f3-43318ff639de.png)
Not sure if we want to show it on mobile, it's a bit awkward but I think it still provides value. Wdyt?

**NOTE:** view with whitespace changes disabled to avoid giant prettier generated diffs 😄 