### PR TITLE
Hotfix/doc guide links

### DIFF
--- a/ts/components/docs/resource/resource.tsx
+++ b/ts/components/docs/resource/resource.tsx
@@ -36,7 +36,7 @@ export const Resource: React.FC<IHitProps> = ({ hit }) => {
     return (
         <ResourceWrapper>
             <Heading color={colors.brandDark} size="small" marginBottom="8px">
-                <Link shouldOpenInNewTab={externalUrl ? true : false} to={to || WebsitePaths.DocsGuides}>
+                <Link shouldOpenInNewTab={externalUrl ? true : false} to={to}>
                     {title}
                 </Link>
             </Heading>

--- a/ts/components/docs/resource/resource.tsx
+++ b/ts/components/docs/resource/resource.tsx
@@ -8,6 +8,7 @@ import { Tag } from 'ts/components/docs/resource/tag';
 import { Heading, Paragraph } from 'ts/components/text';
 
 import { colors } from 'ts/style/colors';
+import { WebsitePaths } from 'ts/types';
 
 interface IHitProps {
     hit: IResourceProps;
@@ -18,18 +19,24 @@ export interface IResourceProps {
     difficulty?: Difficulty;
     externalUrl?: string;
     isCommunity?: boolean;
+    path?: string;
+    id?: string;
     url?: string;
     tags: string[];
 }
 
 export const Resource: React.FC<IHitProps> = ({ hit }) => {
-    const { difficulty, description, externalUrl, isCommunity, tags, title, url } = hit;
-    const to = externalUrl ? externalUrl : url;
-
+    const { difficulty, description, externalUrl, isCommunity, tags, title, url, id } = hit;
+    let to = externalUrl ? externalUrl : url;
+    // HACK(johnrjj)
+    // For some reason, the ABCS of liquidity guide does not return an eternalUrl or url.
+    if (!to) {
+        to = `/docs/guides/${id}`;
+    }
     return (
         <ResourceWrapper>
             <Heading color={colors.brandDark} size="small" marginBottom="8px">
-                <Link shouldOpenInNewTab={externalUrl ? true : false} to={to}>
+                <Link shouldOpenInNewTab={externalUrl ? true : false} to={to || WebsitePaths.DocsGuides}>
                     {title}
                 </Link>
             </Heading>

--- a/ts/pages/api.tsx
+++ b/ts/pages/api.tsx
@@ -66,7 +66,7 @@ const ZeroExApi: React.FC<ApiPageProps> = () => {
 
     return (
         <SiteWrap theme="dark">
-            <DocumentTitle {...documentConstants.ZeroExApi} />
+            <DocumentTitle {...documentConstants.API} />
             <Hero
                 title="Access all DEX liquidity through one API"
                 isLargeTitle={false}


### PR DESCRIPTION
Will actually fix this after launch. Not sure how docs actually work so just patching for now.

Background: the ABCS of contract fillable liquidity does not have an external url or regular url when it gets to the Resource file. It seems to be the only one behaving this way. Not sure how this happened (randomly started failing). The entire docs site crashes if a <Link> is missing the `to` prop, so as a hack we interpret the guide url from the metadata.