### PR TITLE
fix: rename "abcs of cfl" to "intro to... smart contracts"

### DIFF
--- a/mdx/guides/introduction-to-using-0x-liquidity-in-smart-contracts.mdx
+++ b/mdx/guides/introduction-to-using-0x-liquidity-in-smart-contracts.mdx
@@ -37,9 +37,9 @@ After obtaining satisfactory quotes for all necessary token swaps, your smart co
 
 Now that you are familiar with the core concepts of consuming liquidity from a smart contract, let's get started building!
 
-#### [Use 0x API liquidity In Your Smart Contract](./use-0x-api-liquidity-your-smart-contracts.mdx)
+#### Use 0x API liquidity In Your Smart Contract
 
-After finishing this guide, you will have a smart contract buying DAI with ETH. This guide highlights, at a high level, the golden path for integrating network liquidity into your smart contract.
+After finishing [this guide](./use-0x-api-liquidity-in-your-smart-contracts), you will have a smart contract buying DAI with ETH. This guide highlights, at a high level, the golden path for integrating network liquidity into your smart contract.
 
 #### **Coming Soon** Creating a Margin Trading DEFI Product
 

--- a/mdx/guides/swap-tokens-with-0x-api.mdx
+++ b/mdx/guides/swap-tokens-with-0x-api.mdx
@@ -4,7 +4,7 @@
 
 In this guide, we refer to “swap” and “quote” interchangeably. A “quote” is a response from the 0x API describing a transaction that, if executed, would swap the specified tokens.
 
-All code snippets provided are designed to work in a browser environment with an injected web3 instance (like [Metamask](https://metamask.io/)). You can use the[npm web3 module](https://www.npmjs.com/package/web3) and modify these snippets to run them in a node environment.
+All code snippets provided are designed to work in a browser environment with an injected web3 instance (like [Metamask](https://metamask.io/)). You can use the [npm web3 module](https://www.npmjs.com/package/web3) and modify these snippets to run them in a node environment.
 
 ## Swap ETH for 1 DAI
 

--- a/mdx/guides/swap-tokens-with-0x-api.mdx
+++ b/mdx/guides/swap-tokens-with-0x-api.mdx
@@ -223,7 +223,7 @@ const executeQuote = async (quote) => {
 ```
 
 * Leverage 0x TypeScript tooling like `@0x/asset-swapper` or `@0x/contract-wrappers`.
-* Forward the quote to a smart contract to perform the swap on-chain. This relies on concepts introduced in [Introduction to Using 0x API Liquidity In Smart Contracts](./introduction-to-using-0x-api-liquidity-in-smart-contracts.mdx)
+* Forward the quote to a smart contract to perform the swap on-chain. This relies on concepts introduced in [Introduction to Using 0x API Liquidity In Smart Contracts](./introduction-to-using-0x-api-liquidity-in-smart-contracts)
 
 ## Advanced features
 

--- a/mdx/guides/use-0x-api-liquidity-in-your-smart-contracts.mdx
+++ b/mdx/guides/use-0x-api-liquidity-in-your-smart-contracts.mdx
@@ -1,6 +1,6 @@
 # Use 0x API Liquidity in Your Smart Contracts
 
- Allow your users to do simple atomic token swaps in your dApp with 0x API. This guide assumes that you are comfortable with the concept of [leveraging networked liquidity within a smart contract](./introduction-to-using-0x-liquidity-in-smart-contracts.mdx). 
+ Allow your users to do simple atomic token swaps in your dApp with 0x API. This guide assumes that you are comfortable with the concept of [leveraging networked liquidity within a smart contract](./introduction-to-using-0x-liquidity-in-smart-contracts). 
 
 ## Overview
 

--- a/ts/utils/algolia_meta.json
+++ b/ts/utils/algolia_meta.json
@@ -86,14 +86,14 @@
             "difficulty": "Beginner",
             "externalUrl": "https://0x-org.gitbook.io/mesh/getting-started/deployment"
         },
-        "abcs-of-contract-fillable-liquidity": {
-            "title": "ABCs of contract-fillable liquidity",
+        "introduction-to-using-0x-liquidity-in-smart-contracts": {
+            "title": "Introduction to Using 0x Liquidity In Smart Contracts",
             "subtitle": "Integrate 0x’s liquidity into your smart contracts.",
             "description": "Integrate 0x’s liquidity into your smart contracts.",
             "tags": ["CFL"],
             "topics": ["CFL"],
             "difficulty": "Intermediate",
-            "path": "guides/abcs-of-contract-fillable-liquidity.mdx"
+            "path": "guides/introduction-to-using-0x-liquidity-in-smart-contracts.mdx"
         },
         "0x-cheat-sheet": {
             "title": "0x Cheat Sheet",


### PR DESCRIPTION
https://0x.org/docs/guides/abcs-of-contract-fillable-liquidity

This is still linked from the guides indexed page. Leads to a 404.