### PR TITLE
Adds support for displaying pending epoch stake on the staking pool page

### DIFF
--- a/ts/components/staking/dashboard_hero.tsx
+++ b/ts/components/staking/dashboard_hero.tsx
@@ -18,6 +18,7 @@ import { utils } from 'ts/utils/utils';
 interface Metrics {
     title: string;
     number: string | number;
+    headerComponent?: () => JSX.Element;
 }
 
 interface DashBoardHeroTabs {
@@ -106,6 +107,10 @@ const FiguresList = styled.ol`
 `;
 
 const Figure = styled.li`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    text-align: left;
     background-color: ${colors.white};
     padding: 10px;
     margin-right: 15px;
@@ -114,6 +119,12 @@ const Figure = styled.li`
         width: calc(50% - 15px);
         padding: 20px;
     }
+`;
+
+const FigureHeader = styled.header`
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
 `;
 
 const FigureTitle = styled.span`
@@ -323,7 +334,10 @@ export const DashboardHero: React.FC<DashboardHeroProps> = ({
                                 {metrics.map(metric => {
                                     return (
                                         <Figure key={`${metric.title}${metric.number}`}>
-                                            <FigureTitle>{metric.title}</FigureTitle>
+                                            <FigureHeader>
+                                                <FigureTitle>{metric.title}</FigureTitle>
+                                                {metric.headerComponent && metric.headerComponent()}
+                                            </FigureHeader>
                                             <FigureNumber>{metric.number}</FigureNumber>
                                         </Figure>
                                     );

--- a/ts/utils/format_number.test.ts
+++ b/ts/utils/format_number.test.ts
@@ -81,6 +81,16 @@ describe('formatNumber', () => {
         });
         expect(roundedAndMinimized.minimized).toBe('0.000398');
     });
+
+    test('negative number should be formatted with minus sign', () => {
+        // tslint:disable-next-line: number-literal-format
+        const roundedAndMinimized = formatNumber(new BigNumber(-30000.12345), {
+            decimals: 3,
+            decimalsRounded: 3,
+            roundDown: true,
+        });
+        expect(roundedAndMinimized.minimized).toBe('-30,000.123');
+    });
 });
 
 describe('formatPercent', () => {


### PR DESCRIPTION
Adds support to see a better picture of ZRX staked on a staking pool. Interestingly enough, some pools are going up, some are going down (via a tooltip).

Screenshots:

Negative stake to next epoch:

<img width="1281" alt="Screen Shot 2020-02-24 at 11 55 18 AM" src="https://user-images.githubusercontent.com/1103963/75173446-deec5900-56fc-11ea-838d-9ba3b712a4f4.png">

'Positive stake to next epoch:
<img width="1221" alt="Screen Shot 2020-02-24 at 11 55 05 AM" src="https://user-images.githubusercontent.com/1103963/75173466-e9a6ee00-56fc-11ea-8a0f-50b856124ae4.png">
