### PR TITLE
Fixing typo on core concepts

### DIFF
--- a/mdx/core-concepts/index.mdx
+++ b/mdx/core-concepts/index.mdx
@@ -1,6 +1,6 @@
 # Introduction
 
-0x2 is a protocol that facilitates the peer-to-peer exchange of [Ethereum](#ethereum-primer)-based assets. The protocol serves as an open standard and common building block for any developer needing exchange functionality. 0x provides secure [smart contracts](#ethereum-accounts-types) that are externally audited; [developer tools](/docs/tools) tailored to the 0x ecosystem; and open access to a [pool of shared liquidity](#networked-liquidity). Developers can integrate with 0x at the smart contract or application layer.
+0x is a protocol that facilitates the peer-to-peer exchange of [Ethereum](#ethereum-primer)-based assets. The protocol serves as an open standard and common building block for any developer needing exchange functionality. 0x provides secure [smart contracts](#ethereum-accounts-types) that are externally audited; [developer tools](/docs/tools) tailored to the 0x ecosystem; and open access to a [pool of shared liquidity](#networked-liquidity). Developers can integrate with 0x at the smart contract or application layer.
 
 ## What can I build on 0x?
 


### PR DESCRIPTION
Fixed a typo that has been reported a few times: https://0xproject.slack.com/archives/CN767QKRQ/p1582050099041600