### PR TITLE
Fixes rounding issue on the account staking page for pool's rewards shared

### DIFF
--- a/ts/pages/account/account_stake_overview.tsx
+++ b/ts/pages/account/account_stake_overview.tsx
@@ -65,7 +65,7 @@ export const AccountStakeOverview: React.StatelessComponent<StakeOverviewProps> 
 
                 <Stats>
                     <StatFigure label="Fees Generated" value={feesGenerated} />
-                    <StatFigure label="Rewards Shared" value={`${Math.floor(rewardsSharedRatio * 100)}%`} />
+                    <StatFigure label="Rewards Shared" value={`${Math.round(rewardsSharedRatio * 100)}%`} />
                     <StatFigure label="Staked" value={`${Math.floor(stakeRatio * 100)}%`} />
                 </Stats>
             </Flex>


### PR DESCRIPTION
This is more of an edge case, as a user doesn't really use the account page to verify the rewards shared (the staking pool page is always accurate), but wanted to fix it. Anyways, we were rounding down at the edge and we shouldn't, this fixes that.