### PR TITLE
multiple changes to account activity page to optimize for mobile

### DIFF
--- a/ts/components/ui/table_stake_status.tsx
+++ b/ts/components/ui/table_stake_status.tsx
@@ -49,6 +49,5 @@ const StatusText = styled.strong<StatusTextProps>`
 `;
 
 const StatusId = styled.span`
-    font-size: 17px;
     color: ${colors.textDarkSecondary};
 `;

--- a/ts/hooks/use_window_dimensions.ts
+++ b/ts/hooks/use_window_dimensions.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+function getWindowDimensions(): {width: number; height: number} {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export function useWindowDimensions(): {width: number; height: number} {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize(): void {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/ts/pages/account/activity.tsx
+++ b/ts/pages/account/activity.tsx
@@ -19,11 +19,13 @@ import { utils } from 'ts/utils/utils';
 
 import { logUtils } from '@0x/utils';
 import { useAPIClient } from 'ts/hooks/use_api_client';
+import { useWindowDimensions } from 'ts/hooks/use_window_dimensions';
 import { errorReporter } from 'ts/utils/error_reporter';
 
 export interface ActivityProps {}
 
 const columns = ['Event timestamp', 'Event', 'Transaction'];
+const shortWidthColumns = ['Event timestamp', 'Event'];
 
 function parseEvent(event: StakingAPIDelegatorHistoryItem): {title: string; subtitle: string} {
     if (event.eventType === 'earned_rewards') {
@@ -59,6 +61,9 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
     const providerState = useSelector((state: State) => state.providerState);
     const networkId = useSelector((state: State) => state.networkId);
     const dispatch = useDispatch();
+
+    const dimensions = useWindowDimensions();
+    const width = dimensions.width;
 
     const onOpenConnectWalletDialog = React.useCallback(() => {
         const dispatcher = new Dispatcher(dispatch);
@@ -145,7 +150,7 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
                     Activity
                 </Heading>
 
-                <Table columns={columns}>
+                <Table columns={width > 600 ? columns : shortWidthColumns}>
                     {_.map(delegatorHistory, row => {
                         const description = parseEvent(row);
 
@@ -157,6 +162,10 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
                                             year: 'numeric',
                                             month: 'short',
                                             day: '2-digit',
+                                          }).format(new Date(row.eventTimestamp))}
+                                    </strong>
+                                    <strong>
+                                        {Intl.DateTimeFormat('en-US', {
                                             hour: 'numeric',
                                             minute: '2-digit',
                                             second: '2-digit',
@@ -169,11 +178,13 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
                                         subtitle={description.subtitle}
                                     />
                                 </td>
+                                {width > 600 ?
                                 <td>
                                     <a href={utils.getEtherScanLinkIfExists(row.transactionHash, networkId, EtherscanLinkSuffixes.Tx)} target="_blank" rel="noopener">
                                         {row.transactionHash === null ? '-' : utils.getAddressBeginAndEnd(row.transactionHash)}
                                     </a>
                                 </td>
+                                : ``}
                             </tr>
                         );
                     })}
@@ -187,20 +198,26 @@ const ContentWrap = styled.div`
     width: calc(100% - 40px);
     max-width: 1152px;
     margin: 90px auto 0 auto;
+    h1 {
+        font-size: 4vw;
+    }
+    font-size: 3vw;
 
     a {
         color: ${colors.brandLight};
     }
 
-    @media (max-width: 768px) {
+    @media screen and (min-width: 750px) {
         h1 {
-            font-size: 34px;
+            font-size: 24px;
         }
+        font-size: 18px;
     }
 `;
 
 const DateCell = styled.td`
     color: ${colors.textDarkSecondary};
+    white-space: nowrap;
 
     strong {
         display: block;
@@ -210,11 +227,6 @@ const DateCell = styled.td`
 `;
 
 const StyledStakeStatus = styled(StakeStatus)`
-    @media (max-width: 768px) {
-        span {
-            display: none;
-        }
-    }
 `;
 
 const SectionWrapper = styled.div`


### PR DESCRIPTION
Altered the account page to be better optimized for mobile.

Changes include:
- Text size responsive to window width
- Timestamp split across 2 lines and is non-separable
- Event detail text does not disappear with lower window width
- Transaction column disappears for small windows

After:
![image](https://user-images.githubusercontent.com/13876978/80057849-79d69900-84dc-11ea-9235-c04ed402e963.png)


Before:
![image](https://user-images.githubusercontent.com/13876978/80057824-6cb9aa00-84dc-11ea-8985-baaf6b38c6e3.png)
