### PR TITLE
Added a CSV export option to the activity page, added a loading screen

### DIFF
--- a/ts/pages/account/activity.tsx
+++ b/ts/pages/account/activity.tsx
@@ -21,7 +21,7 @@ import { utils } from 'ts/utils/utils';
 import { logUtils } from '@0x/utils';
 import { useAPIClient } from 'ts/hooks/use_api_client';
 import { useWindowDimensions } from 'ts/hooks/use_window_dimensions';
-import { exportCSVFile } from 'ts/utils/csv_export_utils';
+import { exportDataToCSVAndDownloadForUser } from 'ts/utils/csv_export_utils';
 import { errorReporter } from 'ts/utils/error_reporter';
 
 export interface ActivityProps {}
@@ -182,7 +182,14 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
                         isWithArrow={true}
                         isAccentColor={true}
                         shouldUseAnchorTag={true}
-                        onClick={() => {exportCSVFile(csvHeaders, delegatorHistory, 'staking_activity'); }}
+                        onClick={() => {
+                            try {
+                                exportDataToCSVAndDownloadForUser(csvHeaders, delegatorHistory, 'staking_activity');
+                            } catch (e) {
+                                errorReporter.report(e);
+                                alert('Error exporting CSV.');
+                            }}
+                          }
                     >
                         Export to CSV
                     </Button>

--- a/ts/pages/account/activity.tsx
+++ b/ts/pages/account/activity.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import styled from 'styled-components';
 
+import { Button } from 'ts/components/button';
 import { StakingPageLayout } from 'ts/components/staking/layout/staking_page_layout';
 import { Heading } from 'ts/components/text';
 import { Breadcrumb } from 'ts/components/ui/breadcrumb';
@@ -20,6 +21,7 @@ import { utils } from 'ts/utils/utils';
 import { logUtils } from '@0x/utils';
 import { useAPIClient } from 'ts/hooks/use_api_client';
 import { useWindowDimensions } from 'ts/hooks/use_window_dimensions';
+import { exportCSVFile } from 'ts/utils/csv_export_utils';
 import { errorReporter } from 'ts/utils/error_reporter';
 
 export interface ActivityProps {}
@@ -57,6 +59,15 @@ function parseEvent(event: StakingAPIDelegatorHistoryItem): {title: string; subt
     }
 }
 
+const csvHeaders = [
+    'event_type',
+    'address',
+    'block_number',
+    'event_timestamp',
+    'transaction_hash',
+    'event_args',
+];
+
 export const AccountActivity: React.FC<ActivityProps> = () => {
     const providerState = useSelector((state: State) => state.providerState);
     const networkId = useSelector((state: State) => state.networkId);
@@ -76,6 +87,7 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
     const [delegatorHistory, setDelegatorHistory] = React.useState<StakingAPIDelegatorHistoryItem[] | undefined>(undefined);
 
     const accountLoaded = account && account.address;
+    const isDataLoaded = delegatorHistory !== undefined;
 
     const apiClient = useAPIClient(networkId);
 
@@ -137,6 +149,21 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
         },
     ];
 
+    if (!isDataLoaded) {
+        return (
+            <StakingPageLayout title="0x Staking | Activity">
+                <SectionWrapper>
+                    <Heading />
+                    <CallToAction
+                        icon="wallet"
+                        title="Loading"
+                        description="Grabbing data for your wallet."
+                    />
+                </SectionWrapper>
+            </StakingPageLayout>
+        );
+    }
+
     return (
         <StakingPageLayout title="0x Staking | Activity">
             <Breadcrumb crumbs={crumbs} />
@@ -145,17 +172,28 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
                 <Heading
                     asElement="h1"
                     fontWeight="500"
-                    marginBottom="60px"
+                    marginBottom="30px"
                 >
                     Activity
                 </Heading>
+                {width > 600 ?
+                <ButtonWrapper>
+                    <Button
+                        isWithArrow={true}
+                        isAccentColor={true}
+                        shouldUseAnchorTag={true}
+                        onClick={() => {exportCSVFile(csvHeaders, delegatorHistory, 'staking_activity'); }}
+                    >
+                        Export to CSV
+                    </Button>
+                </ButtonWrapper> : `` }
 
                 <Table columns={width > 600 ? columns : shortWidthColumns}>
-                    {_.map(delegatorHistory, row => {
+                    {_.map(delegatorHistory, (row, index) => {
                         const description = parseEvent(row);
 
                         return (
-                            <tr>
+                            <tr key={index}>
                                 <DateCell>
                                     <strong>
                                         {Intl.DateTimeFormat('en-US', {
@@ -184,7 +222,7 @@ export const AccountActivity: React.FC<ActivityProps> = () => {
                                         {row.transactionHash === null ? '-' : utils.getAddressBeginAndEnd(row.transactionHash)}
                                     </a>
                                 </td>
-                                : ``}
+                                : null}
                             </tr>
                         );
                     })}
@@ -237,4 +275,9 @@ const SectionWrapper = styled.div`
     & + & {
         margin-top: 90px;
     }
+`;
+
+const ButtonWrapper = styled.div`
+    margin-left: 1rem;
+    margin-bottom: 22px;
 `;

--- a/ts/utils/csv_export_utils.ts
+++ b/ts/utils/csv_export_utils.ts
@@ -20,7 +20,7 @@ function convertToCSV(
     return str;
 }
 
-export function exportCSVFile(
+export function exportDataToCSVAndDownloadForUser(
     headers: string[],
     objArray: Array<{[key: string]: any}>,
     fileTitle?: string): any {

--- a/ts/utils/csv_export_utils.ts
+++ b/ts/utils/csv_export_utils.ts
@@ -1,0 +1,48 @@
+function convertToCSV(
+    headers: string[],
+    objArray: Array<{[key: string]: any}>): string {
+    let str = `${headers.join('\t')}\r\n`;
+
+    for (const element of objArray) {
+        let line = '';
+        for (const field of Object.keys(element)) {
+            if (line !== '') { line += '\t'; }
+            if (typeof(element[field] === 'object')) {
+                line += JSON.stringify(element[field]);
+            } else {
+                line += element[field];
+            }
+        }
+
+        str += `${line}\r\n`;
+    }
+
+    return str;
+}
+
+export function exportCSVFile(
+    headers: string[],
+    objArray: Array<{[key: string]: any}>,
+    fileTitle?: string): any {
+
+    const csv = convertToCSV(headers, objArray);
+
+    const exportedFilenmae = `${fileTitle}.csv` || 'export.csv';
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    if (navigator.msSaveBlob) { // IE 10+
+        navigator.msSaveBlob(blob, exportedFilenmae);
+    } else {
+        const link = document.createElement('a');
+        if (link.download !== undefined) { // feature detection
+            // Browsers that support HTML5 download attribute
+            const url = URL.createObjectURL(blob);
+            link.setAttribute('href', url);
+            link.setAttribute('download', exportedFilenmae);
+            link.style.visibility = 'hidden';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    }
+}

--- a/ts/utils/csv_export_utils.ts
+++ b/ts/utils/csv_export_utils.ts
@@ -27,18 +27,18 @@ export function exportDataToCSVAndDownloadForUser(
 
     const csv = convertToCSV(headers, objArray);
 
-    const exportedFilenmae = `${fileTitle}.csv` || 'export.csv';
+    const exportedFilename = `${fileTitle}.csv` || 'export.csv';
 
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     if (navigator.msSaveBlob) { // IE 10+
-        navigator.msSaveBlob(blob, exportedFilenmae);
+        navigator.msSaveBlob(blob, exportedFilename);
     } else {
         const link = document.createElement('a');
         if (link.download !== undefined) { // feature detection
             // Browsers that support HTML5 download attribute
             const url = URL.createObjectURL(blob);
             link.setAttribute('href', url);
-            link.setAttribute('download', exportedFilenmae);
+            link.setAttribute('download', exportedFilename);
             link.style.visibility = 'hidden';
             document.body.appendChild(link);
             link.click();


### PR DESCRIPTION
Changes:

- Added an export to CSV for account events
- Added a loading screen once the wallet connects and before data loads

Testing:
- [x] Tested locally

![image](https://user-images.githubusercontent.com/13876978/80527513-5337b880-8949-11ea-89cb-80c676ebc634.png)
