### PR TITLE
Feat: Added rewards section to account page

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "color": "^3.1.2",
         "d3-array": "^2.4.0",
         "date-fns": "^2.8.1",
+        "decimal.js": "^10.2.0",
         "deep-equal": "^1.0.1",
         "ethereum-types": "^3.0.0",
         "ethereumjs-util": "^5.1.1",

--- a/ts/pages/account/account_rewards_overview.tsx
+++ b/ts/pages/account/account_rewards_overview.tsx
@@ -35,17 +35,6 @@ export const AccountRewardsOverview: React.StatelessComponent<RewardOverviewProp
                 >
                     <div>
                         <Heading marginBottom="12px">
-                            Lifetime Rewards
-                        </Heading>
-                        {lifetimeRewards} ETH
-                    </div>
-                </Action>
-                <Action
-                    percentWidth={25}
-                    percentWidthMobile={50}
-                >
-                    <div>
-                        <Heading marginBottom="12px">
                             <FlexHeader>
                                 Estimated for this epoch
                                 <InfoTooltip id="epoch-estimated-rewards">
@@ -54,6 +43,17 @@ export const AccountRewardsOverview: React.StatelessComponent<RewardOverviewProp
                             </FlexHeader>
                         </Heading>
                         {estimatedEpochRewards} ETH
+                    </div>
+                </Action>
+                <Action
+                    percentWidth={25}
+                    percentWidthMobile={50}
+                >
+                    <div>
+                        <Heading marginBottom="12px">
+                            Lifetime Rewards
+                        </Heading>
+                        {lifetimeRewards} ETH
                     </div>
                 </Action>
                 <CollapsibleAction>
@@ -175,8 +175,9 @@ const Action = styled(FlexBase)<ActionProps>`
     }
 
     @media (max-width: 768px) {
-        height: 4em;
+        height: 5.5em;
         width: calc(${props => props.percentWidthMobile ? props.percentWidthMobile : 100}% - 5px);
+        padding: 12px;
         margin-top: 20px;
         font-size: 17px;
 

--- a/ts/pages/account/account_rewards_overview.tsx
+++ b/ts/pages/account/account_rewards_overview.tsx
@@ -1,0 +1,218 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { Button } from 'ts/components/button';
+import { Heading } from 'ts/components/text';
+
+import { colors } from 'ts/style/colors';
+
+interface RewardOverviewProps {
+    totalAvailableRewards: string;
+    estimatedEpochRewards: string;
+    lifetimeRewards: string;
+    onWithdrawRewards: () => void;
+}
+
+export const AccountRewardsOverview: React.StatelessComponent<RewardOverviewProps> = ({
+    totalAvailableRewards = '0',
+    estimatedEpochRewards = '0',
+    lifetimeRewards = '0',
+    onWithdrawRewards,
+}) => {
+    return (
+        <Wrap>
+            <Flex>
+                <Action>
+                    <div>
+                        <LeftJustifiedContent>
+                            <Heading marginBottom="12px">
+                                    Lifetime Rewards
+                            </Heading>
+                            {lifetimeRewards} ETH
+                        </LeftJustifiedContent>
+                    </div>
+                    <div>
+                        <LeftJustifiedContent>
+                            <Heading marginBottom="12px">
+                                Estimated for this epoch
+                            </Heading>
+                            {estimatedEpochRewards} ETH
+                        </LeftJustifiedContent>
+                    </div>
+                </Action>
+                <CollapsibleAction>
+                    <div>
+                        <LeftJustifiedContent>
+                            <Heading marginBottom="12px">
+                                Available Rewards
+                            </Heading>
+                            {totalAvailableRewards} ETH
+                        </LeftJustifiedContent>
+                    </div>
+                    <div>
+                        <ButtonWrapper>
+                            <Button
+                                color={colors.brandLight}
+                                borderColor={colors.border}
+                                bgColor={colors.white}
+                                fontSize="17px"
+                                fontWeight="300"
+                                isNoBorder={true}
+                                padding="15px 35px"
+                                onClick={onWithdrawRewards}
+                            >
+                                Withdraw to Wallet
+                            </Button>
+                        </ButtonWrapper>
+                    </div>
+                </CollapsibleAction>
+            </Flex>
+
+            <MobileActions>
+                <Button
+                    color={colors.white}
+                    borderColor={colors.border}
+                    bgColor={colors.brandLight}
+                    fontSize="17px"
+                    fontWeight="300"
+                    isNoBorder={true}
+                    padding="15px 35px"
+                    onClick={onWithdrawRewards}
+                >
+                    Withdraw Available Rewards ({totalAvailableRewards} ETH)
+                </Button>
+            </MobileActions>
+        </Wrap>
+    );
+};
+
+const Wrap = styled.div`
+    & + & {
+        margin-top: 20px;
+    }
+
+    @media (max-width: 768px) {
+        padding: 20px;
+        /*background: ${colors.backgroundLightGrey};*/
+    }
+`;
+
+const ButtonWrapper = styled.div`
+    @media (min-width: 768px) {
+        font-size: 17px;
+    }
+
+    @media (max-width: 768px) {
+        font-size: 14px;
+    }
+`;
+
+const FlexBase = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+`;
+
+const Flex = styled(FlexBase)`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    @media (min-width: 768px) {
+        padding: 20px 0;
+
+        & + & {
+            border-top: 1px solid ${colors.border};
+        }
+    }
+`;
+
+const LeftJustifiedContent = styled.div`
+    text-align: left;
+    display: inline-block;
+`;
+
+const Action = styled(FlexBase)`
+    background-color: ${colors.backgroundLightGrey};
+    justify-content: center;
+    align-items: center;
+
+    > div {
+        text-align: center;
+        flex: 1;
+        padding: 0.5em;/* add some padding ?*/
+        border-right: 1px solid #D9D9D9;
+    }
+
+    > div:last-child {
+        border: none;
+    }
+
+    @media (min-width: 768px) {
+        height: 7em;
+        width: calc(50% - 10px);
+        padding: 20px;
+        font-size: 17px;
+
+        h1 {
+            font-size: 14px;
+        }
+    }
+
+    @media (max-width: 768px) {
+        height: 4em;
+        width: calc(100%);
+        margin-top: 20px;
+        font-size: 14px;
+
+        h1 {
+            font-size: 12px;
+        }
+    }
+`;
+
+const CollapsibleAction = styled(FlexBase)`
+    background-color: ${colors.backgroundLightGrey};
+    justify-content: center;
+    align-items: center;
+
+    > div {
+        text-align: center;
+        flex: 1;
+        padding: 0.5em;/* add some padding ?*/
+        border-right: 1px solid #D9D9D9;
+    }
+
+    > div:last-child {
+        border: none;
+    }
+
+    @media (min-width: 768px) {
+        height: 7em;
+        width: calc(50% - 10px);
+        padding: 20px;
+        font-size: 17px;
+
+        h1 {
+            font-size: 14px;
+        }
+    }
+
+    @media (max-width: 768px) {
+        display: none;
+    }
+`;
+
+const MobileActions = styled.div`
+    button {
+        display: block;
+        width: 100%;
+    }
+    margin-top: 22px;
+
+    @media (min-width: 768px) {
+        display: none;
+    }
+`;

--- a/ts/pages/account/account_rewards_overview.tsx
+++ b/ts/pages/account/account_rewards_overview.tsx
@@ -93,7 +93,7 @@ export const AccountRewardsOverview: React.StatelessComponent<RewardOverviewProp
                     padding="15px 35px"
                     onClick={onWithdrawRewards}
                 >
-                    Withdraw Available Rewards ({totalAvailableRewards} ETH)
+                    Withdraw Accumulated Rewards ({totalAvailableRewards} ETH)
                 </Button>
             </MobileActions>
         </Wrap>

--- a/ts/pages/account/account_rewards_overview.tsx
+++ b/ts/pages/account/account_rewards_overview.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { Button } from 'ts/components/button';
 import { Heading } from 'ts/components/text';
+import { InfoTooltip } from 'ts/components/ui/info_tooltip';
 
 import { colors } from 'ts/style/colors';
 
@@ -12,6 +13,11 @@ interface RewardOverviewProps {
     estimatedEpochRewards: string;
     lifetimeRewards: string;
     onWithdrawRewards: () => void;
+}
+
+interface ActionProps {
+    percentWidth?: number;
+    percentWidthMobile?: number;
 }
 
 export const AccountRewardsOverview: React.StatelessComponent<RewardOverviewProps> = ({
@@ -23,32 +29,39 @@ export const AccountRewardsOverview: React.StatelessComponent<RewardOverviewProp
     return (
         <Wrap>
             <Flex>
-                <Action>
+                <Action
+                    percentWidth={25}
+                    percentWidthMobile={50}
+                >
                     <div>
-                        <LeftJustifiedContent>
-                            <Heading marginBottom="12px">
-                                    Lifetime Rewards
-                            </Heading>
-                            {lifetimeRewards} ETH
-                        </LeftJustifiedContent>
+                        <Heading marginBottom="12px">
+                            Lifetime Rewards
+                        </Heading>
+                        {lifetimeRewards} ETH
                     </div>
+                </Action>
+                <Action
+                    percentWidth={25}
+                    percentWidthMobile={50}
+                >
                     <div>
-                        <LeftJustifiedContent>
-                            <Heading marginBottom="12px">
+                        <Heading marginBottom="12px">
+                            <FlexHeader>
                                 Estimated for this epoch
-                            </Heading>
-                            {estimatedEpochRewards} ETH
-                        </LeftJustifiedContent>
+                                <InfoTooltip id="epoch-estimated-rewards">
+                                    This estimate is expected to fluctuate at the beginning of an epoch, and progressively converge on the final value.
+                                </InfoTooltip>
+                            </FlexHeader>
+                        </Heading>
+                        {estimatedEpochRewards} ETH
                     </div>
                 </Action>
                 <CollapsibleAction>
                     <div>
-                        <LeftJustifiedContent>
-                            <Heading marginBottom="12px">
-                                Available Rewards
-                            </Heading>
-                            {totalAvailableRewards} ETH
-                        </LeftJustifiedContent>
+                        <Heading marginBottom="12px">
+                            Accumulated Rewards
+                        </Heading>
+                        {totalAvailableRewards} ETH
                     </div>
                     <div>
                         <ButtonWrapper>
@@ -94,7 +107,6 @@ const Wrap = styled.div`
 
     @media (max-width: 768px) {
         padding: 20px;
-        /*background: ${colors.backgroundLightGrey};*/
     }
 `;
 
@@ -129,18 +141,19 @@ const Flex = styled(FlexBase)`
     }
 `;
 
-const LeftJustifiedContent = styled.div`
-    text-align: left;
-    display: inline-block;
+const FlexHeader = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 `;
 
-const Action = styled(FlexBase)`
+const Action = styled(FlexBase)<ActionProps>`
     background-color: ${colors.backgroundLightGrey};
     justify-content: center;
     align-items: center;
 
     > div {
-        text-align: center;
+        text-align: left;
         flex: 1;
         padding: 0.5em;/* add some padding ?*/
         border-right: 1px solid #D9D9D9;
@@ -152,23 +165,23 @@ const Action = styled(FlexBase)`
 
     @media (min-width: 768px) {
         height: 7em;
-        width: calc(50% - 10px);
+        width: calc(${props => props.percentWidth ? props.percentWidth : 100}% - 10px);
         padding: 20px;
-        font-size: 17px;
+        font-size: 20px;
 
         h1 {
-            font-size: 14px;
+            font-size: 17px;
         }
     }
 
     @media (max-width: 768px) {
         height: 4em;
-        width: calc(100%);
+        width: calc(${props => props.percentWidthMobile ? props.percentWidthMobile : 100}% - 5px);
         margin-top: 20px;
-        font-size: 14px;
+        font-size: 17px;
 
         h1 {
-            font-size: 12px;
+            font-size: 14px;
         }
     }
 `;
@@ -179,10 +192,9 @@ const CollapsibleAction = styled(FlexBase)`
     align-items: center;
 
     > div {
-        text-align: center;
+        text-align: left;
         flex: 1;
         padding: 0.5em;/* add some padding ?*/
-        border-right: 1px solid #D9D9D9;
     }
 
     > div:last-child {
@@ -193,10 +205,10 @@ const CollapsibleAction = styled(FlexBase)`
         height: 7em;
         width: calc(50% - 10px);
         padding: 20px;
-        font-size: 17px;
+        font-size: 20px;
 
         h1 {
-            font-size: 14px;
+            font-size: 17px;
         }
     }
 

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -203,10 +203,15 @@ export const Account: React.FC<AccountProps> = () => {
             const _expectedCurrentEpochPoolRewards: ExpectedPoolRewards = {};
 
             for (const pool of delegatorResponse.forCurrentEpoch.poolData) {
-                // account for the case when account belongs to an operator
-                _expectedCurrentEpochPoolRewards[pool.poolId] = (account.address.toLowerCase() === _estimatedRewardsMap[pool.poolId].operatorAddress) ?
-                    _estimatedRewardsMap[pool.poolId].expectedOperatorReward :
-                    ((new BigNumber(pool.zrxStaked)).dividedBy(_estimatedRewardsMap[pool.poolId].memberZrxStaked)).multipliedBy(_estimatedRewardsMap[pool.poolId].expectedMemberReward);
+                if (pool.poolId === null) {
+                    _expectedCurrentEpochPoolRewards[pool.poolId] = new BigNumber(0);
+                } else {
+                    // account for the case when account belongs to an operator
+                    _expectedCurrentEpochPoolRewards[pool.poolId] = (account.address.toLowerCase() === _estimatedRewardsMap[pool.poolId].operatorAddress) ?
+                        _estimatedRewardsMap[pool.poolId].expectedOperatorReward :
+                        ((new BigNumber(pool.zrxStaked)).dividedBy(_estimatedRewardsMap[pool.poolId].memberZrxStaked)).multipliedBy(_estimatedRewardsMap[pool.poolId].expectedMemberReward);
+                }
+
             }
 
             const _expectedCurrentEpochRewards = Object.values(_expectedCurrentEpochPoolRewards).reduce<BigNumber>((prevValue, currentValue) => {

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -134,6 +134,7 @@ export const Account: React.FC<AccountProps> = () => {
     );
 
     const hasDataLoaded = () => Boolean(delegatorData && poolWithStatsMap && availableRewardsMap);
+    const hasRewards = () => Boolean(allTimeRewards.isGreaterThan(0) || expectedCurrentEpochRewards.isGreaterThan(0));
 
     const onChangePool = React.useCallback(
         (fromPoolId: string, toPoolId: string, zrxAmount: number) => {
@@ -490,7 +491,7 @@ export const Account: React.FC<AccountProps> = () => {
             )}
 
             {/* TODO add loading animations or display partially loaded data */}
-            {hasDataLoaded() && (
+            {hasRewards() && (
                 <SectionWrapper>
                     <SectionHeader>
                         <Heading asElement="h3" fontWeight="400" isNoMargin={true}>

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -5,7 +5,6 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
-
 import { Button } from 'ts/components/button';
 import { CallToAction } from 'ts/components/call_to_action';
 import { ChangePoolDialog } from 'ts/components/staking/change_pool_dialog';
@@ -14,10 +13,13 @@ import { RemoveStakeDialog } from 'ts/components/staking/remove_stake_dialog';
 import { Heading } from 'ts/components/text';
 import { InfoTooltip } from 'ts/components/ui/info_tooltip';
 import { StatFigure } from 'ts/components/ui/stat_figure';
+import { useAPIClient } from 'ts/hooks/use_api_client';
+import { useStake } from 'ts/hooks/use_stake';
 import { AccountActivitySummary } from 'ts/pages/account/account_activity_summary';
 import { AccountApplyModal } from 'ts/pages/account/account_apply_modal';
 import { AccountDetail } from 'ts/pages/account/account_detail';
 import { AccountFigure } from 'ts/pages/account/account_figure';
+import { AccountRewardsOverview } from 'ts/pages/account/account_rewards_overview';
 import { AccountStakeOverview } from 'ts/pages/account/account_stake_overview';
 import { AccountVote } from 'ts/pages/account/account_vote';
 import { Dispatcher } from 'ts/redux/dispatcher';
@@ -25,7 +27,7 @@ import { State } from 'ts/redux/reducer';
 import { colors } from 'ts/style/colors';
 import {
     AccountReady,
-    Epoch,
+    EpochWithFees,
     PoolWithStats,
     StakeStatus,
     StakingAPIDelegatorResponse,
@@ -33,13 +35,10 @@ import {
     WebsitePaths,
 } from 'ts/types';
 import { constants } from 'ts/utils/constants';
-import { stakingUtils } from 'ts/utils/staking_utils';
-import { utils } from 'ts/utils/utils';
-
-import { useAPIClient } from 'ts/hooks/use_api_client';
-import { useStake } from 'ts/hooks/use_stake';
 import { errorReporter } from 'ts/utils/error_reporter';
 import { formatEther, formatZrx } from 'ts/utils/format_number';
+import { stakingUtils } from 'ts/utils/staking_utils';
+import { utils } from 'ts/utils/utils';
 
 export interface AccountProps {}
 
@@ -89,6 +88,10 @@ interface PoolDetails {
     zrxAmount: number;
 }
 
+interface ExpectedPoolRewards {
+    [poolId: string]: BigNumber;
+}
+
 export const Account: React.FC<AccountProps> = () => {
     const providerState = useSelector((state: State) => state.providerState);
     const networkId = useSelector((state: State) => state.networkId);
@@ -112,16 +115,23 @@ export const Account: React.FC<AccountProps> = () => {
     const [stakingPools, setStakingPools] = React.useState<PoolWithStats[]>(undefined);
     const [availableRewardsMap, setAvailableRewardsMap] = React.useState<PoolToRewardsMap | undefined>(undefined);
     const [totalAvailableRewards, setTotalAvailableRewards] = React.useState<BigNumber>(new BigNumber(0));
-    const [nextEpochStats, setNextEpochStats] = React.useState<Epoch | undefined>(undefined);
+    const [nextEpochStats, setNextEpochStats] = React.useState<EpochWithFees | undefined>(undefined);
     const [undelegatedBalanceBaseUnits, setUndelegatedBalanceBaseUnits] = React.useState<BigNumber>(new BigNumber(0));
     const [currentEpochStakeMap, setCurrentEpochStakeMap] = React.useState<PoolToDelegatorStakeMap>({});
     const [nextEpochStakeMap, setNextEpochStakeMap] = React.useState<PoolToDelegatorStakeMap>({});
+    const [allTimeRewards, setAllTimeRewards] = React.useState<BigNumber>(new BigNumber(0));
+    // keeping in case we want to make use of by-pool estimated rewards
+    // const [expectedCurrentEpochPoolRewards, setExpectedCurrentEpochPoolRewards] = React.useState<ExpectedPoolRewards>(undefined);
+    const [expectedCurrentEpochRewards, setExpectedCurrentEpochRewards] = React.useState<BigNumber>(new BigNumber(0));
 
     const [pendingActions, setPendingActions] = React.useState<PendingAction[]>([]);
     const [pendingUnstakePoolSet, setPendingUnstakePoolSet] = React.useState<Set<string>>(new Set());
 
     const apiClient = useAPIClient(networkId);
-    const { stakingContract, unstake, withdrawStake, withdrawRewards, moveStake } = useStake(networkId, providerState);
+    const { stakingContract, unstake, withdrawStake, withdrawRewards, moveStake, currentEpochRewards } = useStake(
+        networkId,
+        providerState,
+    );
 
     const hasDataLoaded = () => Boolean(delegatorData && poolWithStatsMap && availableRewardsMap);
 
@@ -136,7 +146,9 @@ export const Account: React.FC<AccountProps> = () => {
                 // automatically send the rewards to the user's address
                 const withdrawnRewards = availableRewardsMap[fromPoolId] ?? 0;
                 if (withdrawnRewards > 0) {
-                    setTotalAvailableRewards(_totalAvailableRewards => _totalAvailableRewards.minus(withdrawnRewards));
+                    setTotalAvailableRewards(_totalAvailableRewards =>
+                        _totalAvailableRewards.minus(withdrawnRewards),
+                    );
                 }
 
                 setNextEpochStakeMap(stakeMap => ({
@@ -154,7 +166,7 @@ export const Account: React.FC<AccountProps> = () => {
             const [delegatorResponse, poolsResponse, epochsResponse] = await Promise.all([
                 apiClient.getDelegatorAsync(account.address),
                 apiClient.getStakingPoolsAsync(),
-                apiClient.getStakingEpochsAsync(),
+                apiClient.getStakingEpochsWithFeesAsync(),
             ]);
 
             const _poolWithStatsMap = poolsResponse.stakingPools.reduce<PoolWithStatsMap>((memo, pool) => {
@@ -177,15 +189,41 @@ export const Account: React.FC<AccountProps> = () => {
                 {},
             );
 
+            const _allTimeRewards = delegatorResponse.allTime.poolData.reduce<BigNumber>((prevValue, currentValue) => {
+                return prevValue.plus(new BigNumber(currentValue.rewardsInEth));
+            }, new BigNumber(0));
+
+            const _estimatedRewardsMap = stakingUtils.getExpectedPoolRewards(
+                poolsResponse.stakingPools,
+                epochsResponse.currentEpoch,
+                currentEpochRewards,
+                true,
+            );
+
+            const _expectedCurrentEpochPoolRewards: ExpectedPoolRewards = {};
+
+            for (const pool of delegatorResponse.forCurrentEpoch.poolData) {
+                // account for the case when account belongs to an operator
+                _expectedCurrentEpochPoolRewards[pool.poolId] = (account.address.toLowerCase() === _estimatedRewardsMap[pool.poolId].operatorAddress) ?
+                    _estimatedRewardsMap[pool.poolId].expectedOperatorReward :
+                    ((new BigNumber(pool.zrxStaked)).dividedBy(_estimatedRewardsMap[pool.poolId].memberZrxStaked)).multipliedBy(_estimatedRewardsMap[pool.poolId].expectedMemberReward);
+            }
+
+            const _expectedCurrentEpochRewards = Object.values(_expectedCurrentEpochPoolRewards).reduce<BigNumber>((prevValue, currentValue) => {
+                return prevValue.plus(new BigNumber(currentValue));
+            }, new BigNumber(0));
+
             setDelegatorData(delegatorResponse);
             setStakingPools(poolsResponse.stakingPools);
             setPoolWithStatsMap(_poolWithStatsMap);
             setNextEpochStats(epochsResponse.nextEpoch);
             setCurrentEpochStakeMap(_currentEpochStakeMap);
             setNextEpochStakeMap(_nextEpochStakeMap);
+            setAllTimeRewards(_allTimeRewards);
+            setExpectedCurrentEpochRewards(_expectedCurrentEpochRewards);
         };
 
-        if (!account.address || isFetchingDelegatorData) {
+        if (!account.address || isFetchingDelegatorData  || !currentEpochRewards) {
             return;
         }
 
@@ -201,12 +239,11 @@ export const Account: React.FC<AccountProps> = () => {
                 errorReporter.report(err);
             });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [account.address, apiClient]); // add isFetchingDelegatorData to dependency arr to turn on polling
+    }, [account.address, apiClient, currentEpochRewards]); // add isFetchingDelegatorData to dependency arr to turn on polling
 
     React.useEffect(() => {
         const fetchAvailableRewards = async () => {
-            const poolsWithAllTimeRewards = delegatorData.allTime.poolData.filter(
-                poolData => poolData.rewardsInEth > 0,
+            const poolsWithAllTimeRewards = delegatorData.allTime.poolData.filter(poolData => poolData.rewardsInEth > 0,
             );
 
             const undelegatedBalancesBaseUnits = await stakingContract
@@ -322,6 +359,21 @@ export const Account: React.FC<AccountProps> = () => {
         );
     }
 
+    if (!hasDataLoaded()) {
+        return (
+            <StakingPageLayout title="0x Staking | Account">
+                <SectionWrapper>
+                    <Heading />
+                    <CallToAction
+                        icon="wallet"
+                        title="Loading"
+                        description="Grabbing data for your wallet."
+                    />
+                </SectionWrapper>
+            </StakingPageLayout>
+        );
+    }
+
     const nextEpochStart = nextEpochStats && new Date(nextEpochStats.epochStart.timestamp);
 
     return (
@@ -369,37 +421,6 @@ export const Account: React.FC<AccountProps> = () => {
                             )}
                         >
                             <StakedZrxBalance delegatorData={delegatorData} />
-                        </AccountFigure>
-
-                        <AccountFigure
-                            label="Rewards"
-                            headerComponent={() => {
-                                if (totalAvailableRewards.gt(0)) {
-                                    return (
-                                        <Button
-                                            isWithArrow={true}
-                                            isTransparent={true}
-                                            fontSize="17px"
-                                            color={colors.brandLight}
-                                            onClick={() => {
-                                                const poolsWithRewards = Object.keys(availableRewardsMap).map(poolId =>
-                                                    utils.toPaddedHex(poolId),
-                                                );
-
-                                                withdrawRewards(poolsWithRewards, () => {
-                                                    setAvailableRewardsMap({});
-                                                    setTotalAvailableRewards(new BigNumber(0));
-                                                });
-                                            }}
-                                        >
-                                            Withdraw
-                                        </Button>
-                                    );
-                                }
-                                return null;
-                            }}
-                        >
-                            <span>{`${formatEther(totalAvailableRewards).minimized} ETH`}</span>
                         </AccountFigure>
                     </Figures>
                 </Inner>
@@ -460,6 +481,40 @@ export const Account: React.FC<AccountProps> = () => {
                             </AccountActivitySummary>
                         );
                     })}
+                </SectionWrapper>
+            )}
+
+            {/* TODO add loading animations or display partially loaded data */}
+            {hasDataLoaded() && (
+                <SectionWrapper>
+                    <SectionHeader>
+                        <Heading asElement="h3" fontWeight="400" isNoMargin={true}>
+                            Your Rewards
+                        </Heading>
+
+                        {/* <Button
+                            color={colors.brandDark}
+                            isWithArrow={true}
+                            isTransparent={true}
+                            onClick={() => toggleApplyModal(true)}
+                        >
+                            Apply to create a staking pool
+                        </Button> */}
+                    </SectionHeader>
+                    <AccountRewardsOverview
+                        totalAvailableRewards={formatEther(totalAvailableRewards).formatted}
+                        estimatedEpochRewards={formatEther(expectedCurrentEpochRewards).formatted}
+                        lifetimeRewards={formatEther(allTimeRewards).formatted}
+                        onWithdrawRewards={() => {
+                            const poolsWithRewards = Object.keys(availableRewardsMap).map(poolId =>
+                                utils.toPaddedHex(poolId),
+                            );
+                            withdrawRewards(poolsWithRewards, () => {
+                                setAvailableRewardsMap({});
+                                setTotalAvailableRewards(new BigNumber(0));
+                            });
+                        }}
+                    />
                 </SectionWrapper>
             )}
 
@@ -628,7 +683,7 @@ const HeaderWrapper = styled.div`
 `;
 
 const Inner = styled.div`
-    @media (min-width: 1200px) {
+    @media (min-width: 1000px) {
         display: flex;
         justify-content: space-between;
     }
@@ -640,7 +695,7 @@ const Inner = styled.div`
 `;
 
 const Figures = styled.div`
-    @media (max-width: 1200px) {
+    @media (max-width: 1000px) {
         padding-top: 24px;
     }
 

--- a/ts/test/fixtures/staking_pools.ts
+++ b/ts/test/fixtures/staking_pools.ts
@@ -22,6 +22,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 5.1665820269124945,
         currentEpochStats: {
             poolId: '6',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 1310928.64,
             shareOfStake: 0.09047059539097367,
             operatorShare: 0.95,
@@ -37,6 +39,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '6',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 1037040.58,
             shareOfStake: 0.06991843803275616,
             operatorShare: 0.95,
@@ -71,6 +75,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 3.5605950106123125,
         currentEpochStats: {
             poolId: '2',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 1018892.02,
             shareOfStake: 0.07031638860869792,
             operatorShare: 0.9,
@@ -88,6 +94,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '2',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 1270633.847553311,
             shareOfStake: 0.08566755790065486,
             operatorShare: 0.9,
@@ -124,6 +132,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 1.2765420635688522,
         currentEpochStats: {
             poolId: '16',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 831137.988,
             zrxStaked: 831137.988,
             shareOfStake: 0.057358994480749104,
             operatorShare: 0.8,
@@ -149,6 +159,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '16',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 1037332.128,
             zrxStaked: 1037332.128,
             shareOfStake: 0.06993809452563088,
             operatorShare: 0.8,
@@ -194,6 +206,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 13.826489115904913,
         currentEpochStats: {
             poolId: '20',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 4831815.30070667,
             shareOfStake: 0.33345614226122094,
             operatorShare: 0.95,
@@ -206,6 +220,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '20',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 6446157.47070667,
             shareOfStake: 0.43460716037263697,
             operatorShare: 0.95,
@@ -236,6 +252,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 13.403197198456905,
         currentEpochStats: {
             poolId: '12',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 5339054.34966063,
             shareOfStake: 0.36846202844310805,
             operatorShare: 0.95,
@@ -253,6 +271,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '12',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 3910585.28966063,
             shareOfStake: 0.2636560425118027,
             operatorShare: 0.95,
@@ -284,6 +304,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '10',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 1,
             shareOfStake: 6.901260116719524e-8,
             operatorShare: 1,
@@ -296,6 +318,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '10',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 1,
             shareOfStake: 6.742112062071492e-8,
             operatorShare: 1,
@@ -322,6 +346,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '7',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.9,
@@ -334,6 +360,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '7',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.9,
@@ -360,6 +388,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '8',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 2510,
             shareOfStake: 0.00017322162892966005,
             operatorShare: 0.925,
@@ -375,6 +405,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '8',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 2510,
             shareOfStake: 0.00016922701275799443,
             operatorShare: 0.925,
@@ -404,6 +436,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '4',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 1,
@@ -416,6 +450,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '4',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 1,
@@ -442,6 +478,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '11',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.95,
@@ -454,6 +492,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '11',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.95,
@@ -480,6 +520,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0.506530390244448,
         currentEpochStats: {
             poolId: '17',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 565218.53,
             shareOfStake: 0.03900720098319838,
             operatorShare: 0.45,
@@ -492,6 +534,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '17',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 528067.4,
             shareOfStake: 0.03560289587126731,
             operatorShare: 0.45,
@@ -518,6 +562,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '3',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 7,
             shareOfStake: 4.830882081703667e-7,
             operatorShare: 1,
@@ -530,6 +576,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '3',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 7,
             shareOfStake: 4.719478443450044e-7,
             operatorShare: 1,
@@ -556,6 +604,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0.04602176750966387,
         currentEpochStats: {
             poolId: '5',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 5858.96,
             shareOfStake: 0.00040434206973455025,
             operatorShare: 1,
@@ -568,6 +618,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '5',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 5558.96,
             shareOfStake: 0.0003747913126857294,
             operatorShare: 1,
@@ -594,6 +646,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '21',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.9,
@@ -606,6 +660,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '21',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.9,
@@ -632,6 +688,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0.19356438109445123,
         currentEpochStats: {
             poolId: '15',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 116629.9,
             shareOfStake: 0.008048932772869865,
             operatorShare: 0.85,
@@ -648,6 +706,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '15',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 115181.56,
             shareOfStake: 0.0077656698500421124,
             operatorShare: 0.85,
@@ -678,6 +738,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '14',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 1,
@@ -690,6 +752,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '14',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 1,
@@ -716,6 +780,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0.1304866339107116,
         currentEpochStats: {
             poolId: '22',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 190002.72,
             shareOfStake: 0.013112581936042271,
             operatorShare: 0.75,
@@ -731,6 +797,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '22',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 167959.62,
             shareOfStake: 0.01132402579942944,
             operatorShare: 0.75,
@@ -760,6 +828,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0.08709576088357711,
         currentEpochStats: {
             poolId: '13',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 147807.74010369822,
             shareOfStake: 0.010200596617200975,
             operatorShare: 1,
@@ -776,6 +846,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '13',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 147805.53010369823,
             shareOfStake: 0.009965214473530147,
             operatorShare: 1,
@@ -806,6 +878,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '9',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 1,
@@ -818,6 +892,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '9',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 1,
@@ -844,6 +920,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '19',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.000095,
@@ -856,6 +934,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '19',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 0,
             shareOfStake: 0,
             operatorShare: 0.000095,
@@ -882,6 +962,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0,
         currentEpochStats: {
             poolId: '1',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 75.65,
             shareOfStake: 0.00000522080327829832,
             operatorShare: 1,
@@ -894,6 +976,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '1',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 104.29,
             shareOfStake: 0.0000070313486695343585,
             operatorShare: 1,
@@ -920,6 +1004,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         avgTotalRewardInEth: 0.18519577776124913,
         currentEpochStats: {
             poolId: '18',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 130167.56,
             shareOfStake: 0.008983201903186957,
             operatorShare: 0.8,
@@ -935,6 +1021,8 @@ const SAMPLE_POOLS: PoolWithStats[] = [
         },
         nextEpochStats: {
             poolId: '18',
+            operatorZrxStaked: 0,
+            memberZrxStaked: 100,
             zrxStaked: 163202.74,
             shareOfStake: 0.011003311619171174,
             operatorShare: 0.8,

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -1121,6 +1121,10 @@ export interface Epoch {
     zrxDeposited: number;
 }
 
+export interface EpochWithFees extends Epoch {
+    protocolFeesGeneratedInEth: number;
+}
+
 export interface PoolMetadata {
     isVerified: boolean;
     logoUrl?: string;
@@ -1175,6 +1179,8 @@ export interface StakingAPIPoolByIdResponse {
 export interface EpochPoolStats {
     poolId: string;
     zrxStaked: number;
+    operatorZrxStaked: number;
+    memberZrxStaked: number;
     shareOfStake: number;
     operatorShare?: number;
     makerAddresses: string[];
@@ -1216,6 +1222,11 @@ export interface PoolEpochRewards extends RewardsStats {
 export interface StakingAPIEpochsResponse {
     currentEpoch: Epoch;
     nextEpoch: Epoch;
+}
+
+export interface StakingAPIEpochsWithFeesResponse {
+    currentEpoch: EpochWithFees;
+    nextEpoch: EpochWithFees;
 }
 
 export interface AllTimeStats {

--- a/ts/utils/api_client.ts
+++ b/ts/utils/api_client.ts
@@ -5,6 +5,7 @@ import {
     StakingAPIDelegatorHistoryItem,
     StakingAPIDelegatorResponse,
     StakingAPIEpochsResponse,
+    StakingAPIEpochsWithFeesResponse,
     StakingAPIPoolByIdResponse,
     StakingAPIPoolsResponse,
     StakingAPIStatsResponse,
@@ -17,6 +18,7 @@ const STAKING_POOLS_ENDPOINT = '/staking/pools';
 const DELEGATOR_ENDPOINT = '/staking/delegator';
 const DELEGATOR_HISTORY_ENDPOINT = '/staking/delegator/events';
 const STAKING_EPOCHS_ENDPOINT = '/staking/epochs';
+const STAKING_EPOCHS_WITH_FEES_ENDPOINT = '/staking/epochs?withFees=true';
 const STAKING_STATS_ENDPOINT = '/staking/stats';
 
 const getStakingPoolByIdEndpoint = (poolId: string) => {
@@ -68,6 +70,14 @@ export class APIClient {
         const result = await fetchUtils.requestAsync<StakingAPIEpochsResponse>(
             utils.getAPIBaseUrl(this.networkId),
             STAKING_EPOCHS_ENDPOINT,
+        );
+        return result;
+    }
+
+    public async getStakingEpochsWithFeesAsync(): Promise<StakingAPIEpochsWithFeesResponse> {
+        const result = await fetchUtils.requestAsync<StakingAPIEpochsWithFeesResponse>(
+            utils.getAPIBaseUrl(this.networkId),
+            STAKING_EPOCHS_WITH_FEES_ENDPOINT,
         );
         return result;
     }

--- a/ts/utils/constants.ts
+++ b/ts/utils/constants.ts
@@ -172,6 +172,7 @@ export const constants = {
     URL_ZEIP_REPO: 'https://github.com/0xProject/ZEIPs/',
     TYPES_SECTION_NAME: 'types',
     COBBS_DOUGLAS_ALPHA: 2 / 3,
+    DELEGATOR_STAKE_WEIGHT: 0.9,
     EXTERNAL_EXPORTS_SECTION_NAME: 'external exports',
     TYPE_TO_SYNTAX: {
         [SupportedDocJson.SolDoc]: 'solidity',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4819,6 +4819,11 @@ decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decimal.js@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.0.tgz#39466113a9e036111d02f82489b5fd6b0b5ed231"
+  integrity sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"


### PR DESCRIPTION
Changes:
- Added Rewards section to account page
- Added loading screen to account page
- Added utility to calculate expected rewards by pool
- Changed pool stats type to include additional fields for operator, member stake
- Added an "EpochWithFees" type to accept an epoch object with total fees

Dependencies:
- https://github.com/0xProject/0x-api/pull/202

Testing:
- [x] Tested locally

Loading screen:
![image](https://user-images.githubusercontent.com/13876978/80847912-33f98f00-8bc6-11ea-9514-f63e4f56fbd3.png)

Rewards section:
![image](https://user-images.githubusercontent.com/13876978/81007766-abb5fc80-8e06-11ea-8053-1a5dea986abb.png)
![image](https://user-images.githubusercontent.com/13876978/81007833-c4261700-8e06-11ea-979b-7b3ec063ab0c.png)

Rewards section mobile view:
![image](https://user-images.githubusercontent.com/13876978/81007897-dc963180-8e06-11ea-9adf-be828daac312.png)

