### PR TITLE
Temporarily subtract 3 days from next epoch start

### DIFF
--- a/ts/components/staking/wizard/wizard_flow.tsx
+++ b/ts/components/staking/wizard/wizard_flow.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from '@0x/utils';
-import { addDays, formatDistanceStrict } from 'date-fns';
+import { addDays, formatDistanceStrict, subDays } from 'date-fns';
 import * as _ from 'lodash';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -535,8 +535,12 @@ export const StartStaking: React.FC<StartStakingProps> = props => {
             return newTotal;
         }, new BigNumber(0)),
     ).minimized;
-    const stakingStartsFormattedTime = stakingUtils.getTimeToEpochDate(new Date(nextEpochStats.epochStart.timestamp));
-    const unlockTokensMinimumFormattedTime = stakingUtils.getTimeToEpochDate(addDays(new Date(nextEpochStats.epochStart.timestamp), constants.STAKING_EPOCH_LENGTH_IN_DAYS));
+    // TODO(kimpers): Remove this after epoch length changes have updated in the contract
+    const nextEpochStart = subDays(new Date(nextEpochStats.epochStart.timestamp), 3);
+    const stakingStartsFormattedTime = stakingUtils.getTimeToEpochDate(nextEpochStart);
+    const unlockTokensMinimumFormattedTime = stakingUtils.getTimeToEpochDate(
+        addDays(nextEpochStart, constants.STAKING_EPOCH_LENGTH_IN_DAYS),
+    );
     return (
         <RelativeContainer>
             <>

--- a/ts/components/staking/wizard/wizard_info.tsx
+++ b/ts/components/staking/wizard/wizard_info.tsx
@@ -1,4 +1,4 @@
-import { addDays, format, formatDistanceStrict } from 'date-fns';
+import { addDays, format, formatDistanceStrict, subDays } from 'date-fns';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -151,7 +151,8 @@ export const IntroWizardInfo: React.FC<WizardInfoProps> = ({ nextEpochStats, all
 };
 
 export const ConfirmationWizardInfo: React.FC<ConfirmationWizardInfo> = ({ nextEpochStats }) => {
-    const stakingStartsEpochDate = new Date(nextEpochStats ? nextEpochStats.epochStart.timestamp : null);
+    // TODO(kimpers): Remove this after epoch length changes have updated in the contract
+    const stakingStartsEpochDate = subDays(new Date(nextEpochStats ? nextEpochStats.epochStart.timestamp : null), 3);
     const firstRewardsEpochDate = addDays(stakingStartsEpochDate, constants.STAKING_EPOCH_LENGTH_IN_DAYS);
 
     const now = new Date();

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -1,6 +1,6 @@
 import { BigNumber, hexUtils, logUtils } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import { format } from 'date-fns';
+import { format, subDays } from 'date-fns';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -370,17 +370,13 @@ export const Account: React.FC<AccountProps> = () => {
             <StakingPageLayout title="0x Staking | Account">
                 <SectionWrapper>
                     <Heading />
-                    <CallToAction
-                        icon="wallet"
-                        title="Loading"
-                        description="Grabbing data for your wallet."
-                    />
+                    <CallToAction icon="wallet" title="Loading" description="Grabbing data for your wallet." />
                 </SectionWrapper>
             </StakingPageLayout>
         );
     }
 
-    const nextEpochStart = nextEpochStats && new Date(nextEpochStats.epochStart.timestamp);
+    const nextEpochStart = nextEpochStats && subDays(new Date(nextEpochStats.epochStart.timestamp), 3);
 
     return (
         <StakingPageLayout title="0x Staking | Account">

--- a/ts/pages/staking/home.tsx
+++ b/ts/pages/staking/home.tsx
@@ -1,4 +1,5 @@
 import { logUtils } from '@0x/utils';
+import { subDays } from 'date-fns';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
@@ -90,7 +91,7 @@ export const StakingIndex: React.FC<StakingIndexProps> = () => {
         fetchAndSetEpochs();
     }, [apiClient]);
 
-    const nextEpochStartDate = nextEpochStats && new Date(nextEpochStats.epochStart.timestamp);
+    const nextEpochStartDate = nextEpochStats && subDays(new Date(nextEpochStats.epochStart.timestamp), 3);
 
     return (
         <StakingPageLayout isHome={true} title="0x Staking">


### PR DESCRIPTION
The current epoch is 7 days, however, the smart contract still returns 10 days due to the timelock for governance changes preventing us from updating it yet. To not confuse we should temporarily subtract 3 days from all `nextEpoch` starting dates until the contract is up to date.

I will follow up with a PR that reverts these changes that we can deploy after the contract state has been updated.