### PR TITLE
Update protocol fee from 150k to 70k everywhere

### DIFF
--- a/mdx/guides/0x-api-faq.mdx
+++ b/mdx/guides/0x-api-faq.mdx
@@ -65,7 +65,7 @@ Ex: 0x API will adjust the price potentially received from Curve Finance by gas 
 
 ## What is the `protocolFee`? 
 
-A protocol fee is paid by takers and ultimately rebated to market makers when their orders are filled. Protocol fees are calculated per order using the gas price multiplied by a constant (currently 150,000). 
+A protocol fee is paid by takers and ultimately rebated to market makers when their orders are filled. Protocol fees are calculated per order using the gas price multiplied by a constant (currently 70,000). 
 
 0x API calculates the required protocol fees to be paid and returns this in the `value` field. Since we recommend using a high gas price, in the event where the taker fills at a lower gas price, the excess is returned. 
 

--- a/mdx/guides/swap-tokens-with-0x-api.mdx
+++ b/mdx/guides/swap-tokens-with-0x-api.mdx
@@ -257,9 +257,9 @@ import * as qs from 'qs';
 ```
 
 ```
-value for gasPrice of 1 wei:  1000000000000150000
-value for gasPrice of 5 wei:  1000000000000750000
-value for gasPrice of 15 wei: 1000000000002250000
+value for gasPrice of 1 wei:  1000000000000070000
+value for gasPrice of 5 wei:  1000000000000140000
+value for gasPrice of 15 wei: 1000000000001050000
 ```
 
 ### Pay protocol fees in WETH

--- a/mdx/guides/swap-tokens-with-0x-api.mdx
+++ b/mdx/guides/swap-tokens-with-0x-api.mdx
@@ -258,7 +258,7 @@ import * as qs from 'qs';
 
 ```
 value for gasPrice of 1 wei:  1000000000000070000
-value for gasPrice of 5 wei:  1000000000000140000
+value for gasPrice of 5 wei:  1000000000000350000
 value for gasPrice of 15 wei: 1000000000001050000
 ```
 
@@ -344,4 +344,3 @@ Now that you’ve got your feet wet with 0x API, here are some other resources t
 
 * Refer to our [0x API specification](../api) for detailed documentation
 * 0x API is [open source](https://github.com/0xProject/0x-api)! Look through the codebase and deploy your own 0x API instance.
-

--- a/mdx/guides/v3-specification.mdx
+++ b/mdx/guides/v3-specification.mdx
@@ -122,7 +122,7 @@ A detailed paper explaining the economics of protocol fees in 0x protocol can be
 
 ### Calculating the protocol fee
 
-The protocol fee can be calculated with `tx.gasprice * protocolFeeMultiplier`, where the `protocolFeeMultiplier` is an upgradable value meant to target a percentage of the gas used for filling a single order. The suggested initial value for the `protocolFeeMultiplier` is `150000`, which is roughly equal to the average gas cost of filling a single order (thereby doubling the net average cost).
+The protocol fee can be calculated with `tx.gasprice * protocolFeeMultiplier`, where the `protocolFeeMultiplier` is an upgradable value meant to target a percentage of the gas used for filling a single order. The current value for the `protocolFeeMultiplier` is `70000`.
 
 ### Protocol fee denomination
 

--- a/mdx/guides/v3-upgrade-guide.mdx
+++ b/mdx/guides/v3-upgrade-guide.mdx
@@ -37,7 +37,7 @@ For a full list of differences in the protocol refer to the [changelog here](/do
 -   Inform your users of your transition from v2 to v3
 -   Allow your users to cancel v2 orders and create new orders for v3. Orders can be created prior to the protocol being upgraded.
 -   [Protocol Fee](#protocol-fee)s will be paid by takers of 0x liquidity, educate your users on this process. It is roughly equivalent to the gas fee already being paid to the miner. Your users will see an increase in the transaction cost in ETH.
--   Become acquainted with the calculation of the protocol fee, `150,000 * ordersFilled * gasPrice`. If your users **lower** their gas price in the wallet the protocol will return the excess fees. If your users **increase** the gas price it is possible the provided ETH value in the transaction is not enough to cover the Protocol Fee.
+-   Become acquainted with the calculation of the protocol fee, `70,000 * ordersFilled * gasPrice`. If your users **lower** their gas price in the wallet the protocol will return the excess fees. If your users **increase** the gas price it is possible the provided ETH value in the transaction is not enough to cover the Protocol Fee.
 
 # Concepts
 


### PR DESCRIPTION
Did a grep for both 150000 and 150,000, and updated all the hits.  These changes are currently deployed to `dogfood`, which is accessible at https://dogfood.0xproject.com/docs/