### PR TITLE
RFQ-T doc tweaks

### DIFF
--- a/mdx/api/index.mdx
+++ b/mdx/api/index.mdx
@@ -968,7 +968,7 @@ Identical to the response schema for `/swap/v0/quote`, with one exception: there
 
 #### Get the price available for selling 1 ETH for DAI
 
-<HttpCall path="/swap/v0/price?sellToken=WETH&buyToken=DAI&sellAmount=1000000000000000000" />
+<HttpCall path="/swap/v0/price?sellToken=WETH&buyToken=DAI&sellAmount=1000000000000000000&takerAddress=0x0123456789abcdef0123456789abcdef01234567" />
 
 <CodeTabs tabs={['200 - OK']}>
 

--- a/mdx/api/index.mdx
+++ b/mdx/api/index.mdx
@@ -960,6 +960,8 @@ Nearly identical to [`/swap/v0/quote`](#get-swapv0quote), but with a few key dif
 
 Identical to the request schema for `/swap/v0/quote`, with one exception: the `skipValidation` parameter will always be considered to be `true`, even when a `takerAddress` has been specified.
 
+Note that while a `takerAddress` is not strictly required, omitting it may result in worse pricing; therefore one should supply it in order to receive the best possible pricing.
+
 ### Response
 
 Identical to the response schema for `/swap/v0/quote`, with one exception: there will never be an `orders` key.

--- a/mdx/api/index.mdx
+++ b/mdx/api/index.mdx
@@ -962,7 +962,7 @@ Identical to the request schema for `/swap/v0/quote`, with one exception: the `s
 
 ### Response
 
-Identical to the response schema for `/swap/v0/quote`, with one exception: the `orders` property will always be undefined.
+Identical to the response schema for `/swap/v0/quote`, with one exception: there will never be an `orders` key.
 
 ### Examples
 

--- a/mdx/guides/rfqt-in-the-0x-api.mdx
+++ b/mdx/guides/rfqt-in-the-0x-api.mdx
@@ -44,7 +44,7 @@ In order to retain access to RFQ-T liquidity, it's important for clients of the 
 
 In order to improve capital efficiency, the RFQ-T model introduces a new request/response flow: first request pricing, then request a fillable quote.
 
-When a market maker provides a fillable quote, which can be settled by the taker's submitting it to the 0x protocol, the taker has an expectation that the swap will actually settle, that it won't revert due to a lack of available maker assets. To uphold this expectation, makers will refrain from using those same assets as the basis for any other quotes, until the quote's expiry.
+When a market maker provides a fillable quote, which can be settled by the taker's submitting it to the 0x protocol, the taker has an expectation that the swap will actually settle, that it won't revert due to a lack of available maker assets. To uphold this expectation, makers will likely refrain from using those same assets as the basis for any other quotes, until the quote's expiry.
 
 However, if every price inquiry required the maker to reserve capital, they would quickly end up with all of their capital in reserve. They would then be unable to provide any other quotes until those outstanding quotes were either filled or expired.
 

--- a/mdx/guides/rfqt-in-the-0x-api.mdx
+++ b/mdx/guides/rfqt-in-the-0x-api.mdx
@@ -129,7 +129,6 @@ To offer a firm quote, a request to GET the endpoint's `/quote` resource must yi
 The 0x API will decline to relay from maker to taker any orders that do not meet the following criteria:
 
 -   `takerAddress` matches what was sent in the request
--   `takerAssetAmount` equal to or less than the `takerAssetAmount` given in the request.
 -   `expirationTimeSeconds` set to a Unix time greater than or equal to 90 seconds in the future. (This number is subject to change as the ecosystem develops.)
 -   `feeRecipientAddress` set to `0x1000000000000000000000000000000000000011`, which will ensure that the fill is attributed to the 0x API.
 

--- a/mdx/guides/rfqt-in-the-0x-api.mdx
+++ b/mdx/guides/rfqt-in-the-0x-api.mdx
@@ -98,7 +98,7 @@ For reference, 0x has provided a basic implementation of a quote server, which d
 
 | Parameter Name        | Parameter Value                                                                                                            | Required? |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `takerAddress`        | The address of the Ethereum account that will act as the 0x taker and that will submit the fill transaction to the network | yes       |
+| `takerAddress`        | The address of the Ethereum account that will act as the 0x taker and that will submit the fill transaction to the network. In the case of indicative pricing, this may be the "null address" (`0x0000000000000000000000000000000000000000`), indicating that the end user has not yet connected their wallet. | yes       |
 | `sellTokenAddress`    | The address of the contract controlling the token to be sold by the taker                                                  | yes       |
 | `buyTokenAddress`     | The address of the contract controlling the token to be bought by the taker                                                | yes       |
 | `sellAmountBaseUnits` | The amount of the `sellToken` that the taker intends to sell, specified in that token's native base units                  | \*        |

--- a/mdx/guides/rfqt-in-the-0x-api.mdx
+++ b/mdx/guides/rfqt-in-the-0x-api.mdx
@@ -10,7 +10,7 @@ RFQ is an abbreviation of Request for Quote, in that the 0x API requests quotes 
 
 Market makers providing open liquidity are subject to unique risks that impact their bottom-line pricing. If asset prices exhibit great movement in the markets, outstanding orders can flip from profitable to loss-incurring. And cancelling outstanding orders can be expensive and unreliable, subject to gas markets and front-running. Carrying these risks has a real cost, and that cost effectively deteriorates pricing for takers.
 
-In practice, such losses are largely at the hands of one particular class of takers: arb bots. If makers share orders with an unspecified/null taker address, as is typical in Mesh order sharing, then those orders can be filled by anyone, including arb bots. Human traders, on the other hand, are extremely unlikely to be able to take advantage of such arbitrage opportunities. If market makers could somehow serve orders only to those human users, they could afford to offer better prices to them.
+In practice, such losses are largely at the hands of one particular class of takers: arbitrage bots. If makers share orders with an unspecified/null taker address, as is typical in Mesh order sharing, then those orders can be filled by anyone, including arb bots. Human traders, on the other hand, are extremely unlikely to be able to take advantage of such arbitrage opportunities. If market makers could somehow serve orders only to those human users, they could afford to offer better prices to them.
 
 # Trusted Takers
 

--- a/mdx/guides/rfqt-in-the-0x-api.mdx
+++ b/mdx/guides/rfqt-in-the-0x-api.mdx
@@ -56,7 +56,7 @@ The indicative pricing resource is hosted at [`/swap/v0/price`](/docs/api#get-sw
 
 ## Firm Quotes
 
-The firm quote resource is hosted at [`/swap/v0/quote`](/docs/api#get-swapv0quote) and responds with a full 0x order, which can be submitted to an Ethereum node by the client. Therefore it is expected that the maker has reserved the maker assets required to settle the trade, leaving the order unlikely to revert.
+The firm quote resource is hosted at [`/swap/v0/quote`](/docs/api#get-swapv0quote) and responds with calldata that can be submitted by the client to an Ethereum node, which will execute the 0x smart contracts to settle the swap. Therefore it is expected that the maker has reserved the maker assets required to settle the trade, leaving the order unlikely to revert.
 
 Note that while the [`/price`](/docs/api#get-swapv0price) resource is new and specific to RFQ-T, the [`/quote`](/docs/api#get-swapv0quote) resource is the same one already used to access non-RFQ-T liquidity through the API. In order to qualify for RFQ-T liquidity, the request must include the query parameter `intentOnFilling=true` (in addition to the aforementioned `0x-api-key` and non-null `takerAddress`).
 


### PR DESCRIPTION
- Responded to @steveklebanoff 's comments in https://github.com/0xProject/website/pull/322
- Documented that `takerAddress` can be null in the indicative quote request to the maker endpoints.