### PR TITLE
Update docs to use 0x API v1 endpoints

### DIFF
--- a/mdx/api/index.mdx
+++ b/mdx/api/index.mdx
@@ -15,7 +15,7 @@ We offer hosted versions for different Ethereum networks. Requests for more netw
 
 Each 0x HTTP API `path` is versioned independently using URI versioning. The format is: `https://api.0x.org/<path>/<version>/<endpoint>`.
 
-For example, you can request `https://api.0x.org/swap/v0/quote` which represents `v0` of the `quote` endpoint in the `swap` path.
+For example, you can request `https://api.0x.org/swap/v1/quote` which represents `v1` of the `quote` endpoint in the `swap` path.
 URLs not adhering to this format are not supported.
 
 A major version bump occurs whenever a backwards incompatible change occurs to an `endpoint`, in which case every `endpoint` in that `path` will be on the next version.
@@ -153,7 +153,7 @@ This API faciliates consuming the best-priced liquidity from [0x Mesh](https://0
 We use smart order routing to split up your transaction across decentralized exchange networks to be filled with the lowest slippage possible.
 Follow the "[Swap Tokens with 0x API](/docs/guides/swap-tokens-with-0x-api)" guide to see how to use it.
 
-## GET /swap/v0/quote
+## GET /swap/v1/quote
 
 Get an easy-to-consume quote for buying or selling any token.
 The return format is a valid unsigned Ethereum transaction and can be submitted directly to an Ethereum node to complete the swap.
@@ -167,7 +167,7 @@ When both are provided, `sellAmount` takes precedence over `buyAmount`.
 | Query Param          | Description                                                                                                                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sellToken`          | The ERC20 token address or symbol of the token you want to send. "ETH" can be provided as a valid `sellToken`.                                                                                                      |
-| `buyToken`           | The ERC20 token address or symbol of the token you want to receive. (`/swap/v0/quote` doesn't support `buyToken` as "ETH", unless quote requested is to [unwrap](/docs/api#examples) "WETH".`)                                                                                                                                                 |
+| `buyToken`           | The ERC20 token address or symbol of the token you want to receive. (`/swap/v1/quote` doesn't support `buyToken` as "ETH", unless quote requested is to [unwrap](/docs/api#examples) "WETH".`)                                                                                                                                                 |
 | `sellAmount`         | (Optional) The amount of `sellToken` (in `sellToken` base units) you want to send.                                                                                                                                       |
 | `buyAmount`          | (Optional) The amount of `buyToken` (in `buyToken` base units) you want to receive.                                                                                                                                      |
 | `slippagePercentage` | (Optional) The maximum acceptable slippage in % of the `buyToken` amount if `sellAmount` is provided, the maximum acceptable slippage in % of the `sellAmount` amount if `buyAmount` is provided. This parameter will change over time with market conditions. |
@@ -206,7 +206,7 @@ When both are provided, `sellAmount` takes precedence over `buyAmount`.
 
 Specify a `buyToken`, `sellToken` and either a `sellAmount` to get a simple quote of 1 WETH for DAI.
 
-<HttpCall fontSize="15px" path="/swap/v0/quote?buyToken=DAI&sellToken=WETH&sellAmount=100000000000000000" />
+<HttpCall fontSize="15px" path="/swap/v1/quote?buyToken=DAI&sellToken=WETH&sellAmount=100000000000000000" />
 
 
 <CodeTabs tabs={['200 - No Taker Address']}>
@@ -317,7 +317,7 @@ Specify a `buyToken`, `sellToken` and either a `sellAmount` to get a simple quot
 #### Excluding liquidity sources
 Supply a comma delimited list of liquidty source names to exclude them from the aggregator logic. See [here](https://github.com/0xProject/0x-monorepo/blob/development/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L27) for a full list of sources.
 
-<HttpCall fontSize="12px" path="/swap/v0/quote?buyToken=DAI&sellToken=ETH&sellAmount=1000000000000000000&excludedSources=0x,Kyber" />
+<HttpCall fontSize="12px" path="/swap/v1/quote?buyToken=DAI&sellToken=ETH&sellAmount=1000000000000000000&excludedSources=0x,Kyber" />
 
 <CodeTabs tabs={['200 - No 0x, Kyber']}>
 
@@ -409,7 +409,7 @@ Supply a comma delimited list of liquidty source names to exclude them from the 
 
 Supply a `takerAddress` to use an [`eth_call`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call) to validate the taker is able to fill the quote.
 
-<HttpCall fontSize="12px" path="/swap/v0/quote?buyToken=DAI&sellToken=ETH&sellAmount=1000000000000000000&takerAddress=0xab5801a7d398351b8be11c439e05c5b3259aec9b" />
+<HttpCall fontSize="12px" path="/swap/v1/quote?buyToken=DAI&sellToken=ETH&sellAmount=1000000000000000000&takerAddress=0xab5801a7d398351b8be11c439e05c5b3259aec9b" />
 
 <CodeTabs tabs={['200 - Taker Address']}>
 
@@ -538,7 +538,7 @@ If the [`eth_call`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call) fai
 
 Use "ETH" as the `sellToken` to receive a [Forwarder](/docs/guides/v3-forwarder-specification) transaction, which will allow you to swap without having set allowances on your tokens. Note: The Forwarder contract is updated over time and may have a different address.
 
-<HttpCall fontSize="16px" path="/swap/v0/quote?buyToken=DAI&sellToken=ETH&sellAmount=1000000000000000000" />
+<HttpCall fontSize="16px" path="/swap/v1/quote?buyToken=DAI&sellToken=ETH&sellAmount=1000000000000000000" />
 
 <CodeTabs tabs={['200 - Forwarder Transaction']}>
 
@@ -632,7 +632,7 @@ Easily wrap and unwrap between ETH and WETH by requesting a swap quote by settin
 
 ##### Wrap ETH
 
-<HttpCall fontSize="16px" path="/swap/v0/quote?buyToken=ETH&sellToken=WETH&buyAmount=10000000" />
+<HttpCall fontSize="16px" path="/swap/v1/quote?buyToken=ETH&sellToken=WETH&buyAmount=10000000" />
 
 <CodeTabs tabs={['200 - Wrapping Transaction']}>
 
@@ -661,7 +661,7 @@ Easily wrap and unwrap between ETH and WETH by requesting a swap quote by settin
 
 ##### Unwrap WETH
 
-<HttpCall fontSize="16px" path="/swap/v0/quote?buyToken=WETH&sellToken=ETH&buyAmount=10000000" />
+<HttpCall fontSize="16px" path="/swap/v1/quote?buyToken=WETH&sellToken=ETH&buyAmount=10000000" />
 
 <CodeTabs tabs={['200 - Unwrapping Transaction']}>
 
@@ -692,7 +692,7 @@ Easily wrap and unwrap between ETH and WETH by requesting a swap quote by settin
 
 RFQ-T liquidity can only be accessed if the request supplies a taker address, a permissioned API key via header `0x-api-key`, and the query parameter `intentOnFilling=true`. For more details see the guide [Understanding RFQ-T and the 0x API](/docs/guides/rfqt-in-the-0x-api).
 
-<HttpCall fontSize="16px" path="/swap/v0/quote?sellToken=WETH&buyToken=DAI&sellAmount=1000000000000000000&takerAddress=0xffffffffffffffffffffffffffffffffffffffff&intentOnFilling=true" />
+<HttpCall fontSize="16px" path="/swap/v1/quote?sellToken=WETH&buyToken=DAI&sellAmount=1000000000000000000&takerAddress=0xffffffffffffffffffffffffffffffffffffffff&intentOnFilling=true" />
 
 <CodeTabs tabs={['200 - RFQ-T-enabled']}>
 
@@ -797,9 +797,9 @@ RFQ-T liquidity can only be accessed if the request supplies a taker address, a 
 ```
 </CodeTabs>
 
-## GET /swap/v0/tokens
+## GET /swap/v1/tokens
 
-Get the tokens with known symbols available for trading in the [`/swap/v0/quote`](#get-swapv0quote) endpoint.
+Get the tokens with known symbols available for trading in the [`/swap/v1/quote`](#get-swapv1quote) endpoint.
 If a token is not returned, it may still be available but not queryable by token symbol.
 
 ### Request
@@ -821,7 +821,7 @@ No request params.
 
 #### Get all available tokens
 
-<HttpCall path="/swap/v0/tokens" />
+<HttpCall path="/swap/v1/tokens" />
 
 <CodeTabs tabs={['200 - OK']}>
 
@@ -899,9 +899,9 @@ No request params.
 ```
 </CodeTabs>
 
-## GET /swap/v0/prices
+## GET /swap/v1/prices
 
-Get the amount of `sellToken` to purchase one unit (not base unit, one unit adjusted by number of decimals for asset) for tokens supported by `/swap/v0/*` endpoints.
+Get the amount of `sellToken` to purchase one unit (not base unit, one unit adjusted by number of decimals for asset) for tokens supported by `/swap/v1/*` endpoints.
 If a token is not returned, it may still be available but not queryable by token symbol.
 
 ### Request
@@ -923,7 +923,7 @@ Response will be an array of token symbols and the respective price in `sellToke
 
 #### Get price of tokens in DAI
 
-<HttpCall path="/swap/v0/prices?sellToken=DAI" />
+<HttpCall path="/swap/v1/prices?sellToken=DAI" />
 
 <CodeTabs tabs={['200 - OK']}>
 
@@ -952,23 +952,23 @@ Response will be an array of token symbols and the respective price in `sellToke
 
 </CodeTabs>
 
-## GET /swap/v0/price
+## GET /swap/v1/price
 
-Nearly identical to [`/swap/v0/quote`](#get-swapv0quote), but with a few key differences. Rather than returning a transaction that can be submitted to an Ethereum node, this resource simply indicates the pricing that would be available for an analogous call to `/swap/v0/quote`. Intended for use with RFQ-T; see [Quote Types: Indicative vs Firm](/docs/guides/rfqt-in-the-0x-api#quote-types-indicative-vs-firm) for more details.
+Nearly identical to [`/swap/v1/quote`](#get-swapv1quote), but with a few key differences. Rather than returning a transaction that can be submitted to an Ethereum node, this resource simply indicates the pricing that would be available for an analogous call to `/swap/v1/quote`. Intended for use with RFQ-T; see [Quote Types: Indicative vs Firm](/docs/guides/rfqt-in-the-0x-api#quote-types-indicative-vs-firm) for more details.
 
 ### Request
 
-Identical to the request schema for `/swap/v0/quote`, with one exception: the `skipValidation` parameter will always be considered to be `true`, even when a `takerAddress` has been specified.
+Identical to the request schema for `/swap/v1/quote`, with one exception: the `skipValidation` parameter will always be considered to be `true`, even when a `takerAddress` has been specified.
 
 ### Response
 
-Identical to the response schema for `/swap/v0/quote`, with one exception: the `orders` property will always be undefined.
+Identical to the response schema for `/swap/v1/quote`, with one exception: the `orders` property will always be undefined.
 
 ### Examples
 
 #### Get the price available for selling 1 ETH for DAI
 
-<HttpCall path="/swap/v0/price?sellToken=WETH&buyToken=DAI&sellAmount=1000000000000000000" />
+<HttpCall path="/swap/v1/price?sellToken=WETH&buyToken=DAI&sellAmount=1000000000000000000" />
 
 <CodeTabs tabs={['200 - OK']}>
 

--- a/mdx/api/index.mdx
+++ b/mdx/api/index.mdx
@@ -167,7 +167,7 @@ When both are provided, `sellAmount` takes precedence over `buyAmount`.
 | Query Param          | Description                                                                                                                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sellToken`          | The ERC20 token address or symbol of the token you want to send. "ETH" can be provided as a valid `sellToken`.                                                                                                      |
-| `buyToken`           | The ERC20 token address or symbol of the token you want to receive. (`/swap/v1/quote` doesn't support `buyToken` as "ETH", unless quote requested is to [unwrap](/docs/api#examples) "WETH".`)                                                                                                                                                 |
+| `buyToken`           | The ERC20 token address or symbol of the token you want to receive. "ETH" can be provided as a valid `buyToken`
 | `sellAmount`         | (Optional) The amount of `sellToken` (in `sellToken` base units) you want to send.                                                                                                                                       |
 | `buyAmount`          | (Optional) The amount of `buyToken` (in `buyToken` base units) you want to receive.                                                                                                                                      |
 | `slippagePercentage` | (Optional) The maximum acceptable slippage in % of the `buyToken` amount if `sellAmount` is provided, the maximum acceptable slippage in % of the `sellAmount` amount if `buyAmount` is provided. This parameter will change over time with market conditions. |
@@ -309,7 +309,8 @@ Specify a `buyToken`, `sellToken` and either a `sellAmount` to get a simple quot
       "takerFeeAssetData": "0x",
       "signature": "0x04"
     }
-  ]
+  ],
+  "allowanceTarget": "0xf740b67da229f2f10bcbd38a7979992fcc71b8eb"
 }
 ```
 </CodeTabs>
@@ -400,7 +401,8 @@ Supply a comma delimited list of liquidty source names to exclude them from the 
       "takerFeeAssetData": "0x",
       "signature": "0x04"
     }
-  ]
+  ],
+  "allowanceTarget": "0x0000000000000000000000000000000000000000"
 }
 ```
 </CodeTabs>
@@ -512,7 +514,8 @@ Supply a `takerAddress` to use an [`eth_call`](https://github.com/ethereum/wiki/
       "takerFeeAssetData": "0x",
       "signature": "0x04"
     }
-  ]
+  ],
+  "allowanceTarget": "0x0000000000000000000000000000000000000000"
 }
 ```
 </CodeTabs>
@@ -621,7 +624,8 @@ Use "ETH" as the `sellToken` to receive a [Forwarder](/docs/guides/v3-forwarder-
       "takerFeeAssetData": "0x",
       "signature": "0x04"
     }
-  ]
+  ],
+  "allowanceTarget": "0x0000000000000000000000000000000000000000"
 }
 ```
 </CodeTabs>
@@ -654,7 +658,8 @@ Easily wrap and unwrap between ETH and WETH by requesting a swap quote by settin
   "buyAmount": "10000000",
   "sellAmount": "10000000",
   "sources": [],
-  "orders": []
+  "orders": [],
+  "allowanceTarget": "0x0000000000000000000000000000000000000000"
 }
 ```
 </CodeTabs>
@@ -683,7 +688,8 @@ Easily wrap and unwrap between ETH and WETH by requesting a swap quote by settin
   "buyAmount": "10000000",
   "sellAmount": "10000000",
   "sources": [],
-  "orders": []
+  "orders": [],
+  "allowanceTarget": "0x0000000000000000000000000000000000000000"
 }
 ```
 </CodeTabs>
@@ -792,7 +798,7 @@ RFQ-T liquidity can only be accessed if the request supplies a taker address, a 
             "signature": "0x04"
         }
     ],
-    "allowanceTarget": "0x95e6f48254609a6ee006f7d493c8e5fb97094cef"
+    "allowanceTarget": "0xf740b67da229f2f10bcbd38a7979992fcc71b8eb"
 }
 ```
 </CodeTabs>
@@ -1024,7 +1030,7 @@ Identical to the response schema for `/swap/v1/quote`, with one exception: the `
         }
     ],
     "estimatedGasTokenRefund": "252480",
-    "allowanceTarget": "0x95e6f48254609a6ee006f7d493c8e5fb97094cef"
+    "allowanceTarget": "0xf740b67da229f2f10bcbd38a7979992fcc71b8eb"
 }
 ```
 

--- a/mdx/api/index.mdx
+++ b/mdx/api/index.mdx
@@ -199,6 +199,7 @@ When both are provided, `sellAmount` takes precedence over `buyAmount`.
 | `sellTokenAddress`        | The ERC20 token address of the token you want to sell with quote.                                                                                                                               |
 | `orders`                  | [Signed orders](/docs/api#signed-order) that data is comprised of.                                                                                                                               |
 | `estimatedGasTokenRefund` | When possible, the 0x smart contracts will burn GST2 [Gas Tokens](https://gastoken.io/) during the transaction, resulting in a (max 50%) ETH refund at the end of the transaction. This field estimates the refund in wei.                  |
+| `allowanceTarget`         | The target contract address for which the user needs to have an allowance in order to be able to complete the swap. For swaps with "ETH" as `sellToken`, wrapping "ETH" to "WETH" or unwrapping "WETH" to "ETH" no allowance is needed, a null address of `0x0000000000000000000000000000000000000000` is then returned instead. |
 
 ### Examples
 

--- a/mdx/guides/develop-a-margin-trading-smart-contract-with-0x-api.mdx
+++ b/mdx/guides/develop-a-margin-trading-smart-contract-with-0x-api.mdx
@@ -129,10 +129,7 @@ The function signature for the `open` function is defined as so:
 
 ```solidity
 // contracts/SimpleMarginTrading.sol
-function open(
-    ZeroExQuote memory quote,
-    address allowanceTarget
-)
+function open(ZeroExQuote memory quote)
     public
     payable
     onlyowner
@@ -150,10 +147,7 @@ The function will only allow the `owner` to open a position and only when the sm
 With the `protocolFee` introduced in version 3 of 0x protocol, some of the ETH sent along the transaction will be reserved to pay the `protocolFee`. Before we deposit ETH into Compound finance, we will need to calculate how much of `msg.value` we can deposit.
 
 ```solidity
-function open(
-    ZeroExQuote memory quote,
-    address allowanceTarget
-)
+function open(ZeroExQuote memory quote)
   public
   payable
   onlyOwner
@@ -195,7 +189,7 @@ To swap with 0x, the 0x exchange contracts will need to have access to move DAI 
 ```solidity
     ...
     // 4. approve 0x exchange to move DAI
-    _approve(address(dai), allowanceTarget);
+    _approve(address(dai), quote.allowanceTarget);
     ...
 ```
 
@@ -236,10 +230,7 @@ At this point, the open function should look like this:
 
 ```solidity
     // contracts/SimpleMarginTrading.sol
-    function open(
-        ZeroExQuote memory quote,
-        address allowanceTarget
-    )
+    function open(ZeroExQuote memory quote)
         public
         payable
         onlyOwner
@@ -253,7 +244,7 @@ At this point, the open function should look like this:
         // 3. borrow token
         require(cdai.borrow(quote.sellAmount) == 0, "Failed to borrow cDAI from Compound Finance");
         // 4. approve 0x exchange to move DAI
-        _approve(address(dai), allowanceTarget);
+        _approve(address(dai), quote.allowanceTarget);
         // 5. execute and verify swap
         require(quote.sellToken == address(weth), "Provided quote is not selling WEth");
         require(quote.buyToken == address(dai), "Provided quote is not buying Dai");
@@ -283,10 +274,7 @@ If ETH has risen in price, then you will have more remaining WETH after buying D
 Let’s begin by defining the function signature for `close`:
 
 ```solidity
-function close(
-    ZeroExQuote memory quote,
-    address allowanceTarget
-)
+function close(ZeroExQuote memory quote)
     public
     payable
     onlyOwner
@@ -313,7 +301,7 @@ Similar to swapping from DAI to WETH in `open`, we will need to do a few things 
 ```solidity
     ...
     // 2. approve 0x exchange to move WETH
-    _approve(address(weth), allowanceTarget);
+    _approve(address(weth), quote.allowanceTarget);
     // 3. verify swap amounts are enough to repay balance
     uint256 wethBalance = weth.balanceOf(address(this));
     uint256 daiBorrowBalance = cdai.borrowBalanceCurrent(address(this));
@@ -373,10 +361,7 @@ At this point, the contract holds ETH and WETH (whatever WETH remains not swappe
 At this point `close` function should look something like this:
 
 ```solidity
-    function close(
-       ZeroExQuote memory quote,
-       address allowanceTarget
-    )
+    function close(ZeroExQuote memory quote)
         public
         payable
         onlyOwner
@@ -386,7 +371,7 @@ At this point `close` function should look something like this:
         // 1. wrap extra ETH sent with tx to buy DAI (additional ETH is sent to pay for interest rate)
         weth.deposit.value(msg.value.safeSub(quote.protocolFee))();
         // 2. approve 0x exchange to move WETH
-        _approve(address(weth), allowanceTarget);
+        _approve(address(weth), quote.allowanceTarget);
         // 3. verify swap amounts are enough to repay balance
         uint256 wethBalance = weth.balanceOf(address(this));
         uint256 daiBorrowBalance = cdai.borrowBalanceCurrent(address(this));
@@ -484,9 +469,9 @@ const onchainPassableQuote = {
     sellAmount: quote.sellAmount,
     protocolFee: quote.protocolFee,
     calldataHex: quote.data,
+    allowanceTarget: quote.allowanceTarget,
 };
 const value = positionSize.plus(quote.protocolFee);
-const allowanceTarget = quote.allowanceTarget;
 ```
 
 Since we will be using ETH to pay protocol fees with 0x, we will need to send additional ETH with the transaction along with the `positionSize`. With the above variables, let’s call the smart contract.
@@ -494,7 +479,7 @@ Since we will be using ETH to pay protocol fees with 0x, we will need to send ad
 ```typescript
 // 3. execute a smart contract call to open a margin position
 try {
-    const results = await contract.open(onchainPassableQuote, allowanceTarget).callAsync({
+    const results = await contract.open(onchainPassableQuote).callAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,
@@ -504,7 +489,7 @@ try {
     console.log(`position size: (ETH in Compound + WETH): ${results[0]}`);
     console.log(`dai borrowed from Compound: ${results[1]}`);
     
-    await contract.open(onchainPassableQuote, allowanceTarget).awaitTransactionSuccessAsync({
+    await contract.open(onchainPassableQuote).awaitTransactionSuccessAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,
@@ -571,6 +556,7 @@ const onchainPassableQuote = {
     sellAmount: quote.sellAmount,
     protocolFee: quote.protocolFee,
     calldataHex: quote.data,
+    allowanceTarget: quote.allowanceTarget,
 };
 
 ...
@@ -583,7 +569,6 @@ To pay the additional interest from borrowing, we will be sending some more ETH 
 // 3. calculate and provide an extra buffer of WETH to pay interest accrued.
 const extraWethBuffer = new BigNumber(quote.sellAmount).times(0.01);
 const value = (new BigNumber(quote.protocolFee)).plus(extraWethBuffer).integerValue();
-const allowanceTarget = quote.allowanceTarget;
 ...
 ```
 
@@ -594,7 +579,7 @@ Now, let’s call the smart contract:
 ...
 // 4. execute a smart contract call to open a margin position
 try {
-    const results = await contract.close(onchainPassableQuote, allowanceTarget).callAsync({
+    const results = await contract.close(onchainPassableQuote).callAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,
@@ -603,7 +588,7 @@ try {
 
     console.log(`eth balance size after closing position: ${results}`);
 
-    await contract.close(onchainPassableQuote, allowanceTarget).awaitTransactionSuccessAsync({
+    await contract.close(onchainPassableQuote).awaitTransactionSuccessAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,

--- a/mdx/guides/develop-a-margin-trading-smart-contract-with-0x-api.mdx
+++ b/mdx/guides/develop-a-margin-trading-smart-contract-with-0x-api.mdx
@@ -129,7 +129,10 @@ The function signature for the `open` function is defined as so:
 
 ```solidity
 // contracts/SimpleMarginTrading.sol
-function open(ZeroExQuote memory quote)
+function open(
+    ZeroExQuote memory quote,
+    address allowanceTarget
+)
     public
     payable
     onlyowner
@@ -147,7 +150,10 @@ The function will only allow the `owner` to open a position and only when the sm
 With the `protocolFee` introduced in version 3 of 0x protocol, some of the ETH sent along the transaction will be reserved to pay the `protocolFee`. Before we deposit ETH into Compound finance, we will need to calculate how much of `msg.value` we can deposit.
 
 ```solidity
-function open(ZeroExQuote memory quote)
+function open(
+    ZeroExQuote memory quote,
+    address allowanceTarget
+)
   public
   payable
   onlyOwner
@@ -189,7 +195,7 @@ To swap with 0x, the 0x exchange contracts will need to have access to move DAI 
 ```solidity
     ...
     // 4. approve 0x exchange to move DAI
-    _approve(address(dai), _getZeroExApprovalAddress());
+    _approve(address(dai), allowanceTarget);
     ...
 ```
 
@@ -230,7 +236,10 @@ At this point, the open function should look like this:
 
 ```solidity
     // contracts/SimpleMarginTrading.sol
-    function open(ZeroExQuote memory quote)
+    function open(
+        ZeroExQuote memory quote,
+        address allowanceTarget
+    )
         public
         payable
         onlyOwner
@@ -244,7 +253,7 @@ At this point, the open function should look like this:
         // 3. borrow token
         require(cdai.borrow(quote.sellAmount) == 0, "Failed to borrow cDAI from Compound Finance");
         // 4. approve 0x exchange to move DAI
-        _approve(address(dai), _getZeroExApprovalAddress());
+        _approve(address(dai), allowanceTarget);
         // 5. execute and verify swap
         require(quote.sellToken == address(weth), "Provided quote is not selling WEth");
         require(quote.buyToken == address(dai), "Provided quote is not buying Dai");
@@ -275,7 +284,8 @@ Let’s begin by defining the function signature for `close`:
 
 ```solidity
 function close(
-    ZeroExQuote memory quote
+    ZeroExQuote memory quote,
+    address allowanceTarget
 )
     public
     payable
@@ -303,7 +313,7 @@ Similar to swapping from DAI to WETH in `open`, we will need to do a few things 
 ```solidity
     ...
     // 2. approve 0x exchange to move WETH
-    _approve(address(weth), _getZeroExApprovalAddress());
+    _approve(address(weth), allowanceTarget);
     // 3. verify swap amounts are enough to repay balance
     uint256 wethBalance = weth.balanceOf(address(this));
     uint256 daiBorrowBalance = cdai.borrowBalanceCurrent(address(this));
@@ -364,7 +374,8 @@ At this point `close` function should look something like this:
 
 ```solidity
     function close(
-       ZeroExQuote memory quote
+       ZeroExQuote memory quote,
+       address allowanceTarget
     )
         public
         payable
@@ -375,7 +386,7 @@ At this point `close` function should look something like this:
         // 1. wrap extra ETH sent with tx to buy DAI (additional ETH is sent to pay for interest rate)
         weth.deposit.value(msg.value.safeSub(quote.protocolFee))();
         // 2. approve 0x exchange to move WETH
-        _approve(address(weth), _getZeroExApprovalAddress());
+        _approve(address(weth), allowanceTarget);
         // 3. verify swap amounts are enough to repay balance
         uint256 wethBalance = weth.balanceOf(address(this));
         uint256 daiBorrowBalance = cdai.borrowBalanceCurrent(address(this));
@@ -475,6 +486,7 @@ const onchainPassableQuote = {
     calldataHex: quote.data,
 };
 const value = positionSize.plus(quote.protocolFee);
+const allowanceTarget = quote.allowanceTarget;
 ```
 
 Since we will be using ETH to pay protocol fees with 0x, we will need to send additional ETH with the transaction along with the `positionSize`. With the above variables, let’s call the smart contract.
@@ -482,7 +494,7 @@ Since we will be using ETH to pay protocol fees with 0x, we will need to send ad
 ```typescript
 // 3. execute a smart contract call to open a margin position
 try {
-    const results = await contract.open(onchainPassableQuote).callAsync({
+    const results = await contract.open(onchainPassableQuote, allowanceTarget).callAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,
@@ -492,7 +504,7 @@ try {
     console.log(`position size: (ETH in Compound + WETH): ${results[0]}`);
     console.log(`dai borrowed from Compound: ${results[1]}`);
     
-    await contract.open(onchainPassableQuote).awaitTransactionSuccessAsync({
+    await contract.open(onchainPassableQuote, allowanceTarget).awaitTransactionSuccessAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,
@@ -571,6 +583,7 @@ To pay the additional interest from borrowing, we will be sending some more ETH 
 // 3. calculate and provide an extra buffer of WETH to pay interest accrued.
 const extraWethBuffer = new BigNumber(quote.sellAmount).times(0.01);
 const value = (new BigNumber(quote.protocolFee)).plus(extraWethBuffer).integerValue();
+const allowanceTarget = quote.allowanceTarget;
 ...
 ```
 
@@ -581,7 +594,7 @@ Now, let’s call the smart contract:
 ...
 // 4. execute a smart contract call to open a margin position
 try {
-    const results = await contract.close(onchainPassableQuote).callAsync({
+    const results = await contract.close(onchainPassableQuote, allowanceTarget).callAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,
@@ -590,7 +603,7 @@ try {
 
     console.log(`eth balance size after closing position: ${results}`);
 
-    await contract.close(onchainPassableQuote).awaitTransactionSuccessAsync({
+    await contract.close(onchainPassableQuote, allowanceTarget).awaitTransactionSuccessAsync({
         from: takerAddress,
         value,
         gasPrice: quote.gasPrice,

--- a/mdx/guides/develop-a-margin-trading-smart-contract-with-0x-api.mdx
+++ b/mdx/guides/develop-a-margin-trading-smart-contract-with-0x-api.mdx
@@ -25,7 +25,7 @@ $ cd 0x-api-starter-guide-code
 $ npm install
 ```
 
-For development, we will be leveraging the Kovan test network and the respective kovan 0x api endpoint: `kovan.api.0x.org/swap/v0/quote`. 
+For development, we will be leveraging the Kovan test network and the respective kovan 0x api endpoint: `kovan.api.0x.org/swap/v1/quote`. 
 
 ### Configure the .env file
 
@@ -457,7 +457,7 @@ const params = {
     excludedSources: 'Eth2Dai,Uniswap,Kyber',
 }
 
-const res = await fetch(`https://kovan.api.0x.org/swap/v0/quote?${qs.stringify(params)}`);
+const res = await fetch(`https://kovan.api.0x.org/swap/v1/quote?${qs.stringify(params)}`);
 const quote = await res.json();
 ...
 ```
@@ -549,7 +549,7 @@ const params = {
     buyAmount: daiBorrowBalance.toString(),
 }
 
-const res = await fetch(`https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`);
+const res = await fetch(`https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`);
 const quote = await res.json();
 
 const onchainPassableQuote = {

--- a/mdx/guides/migrate-0x-api-from-v0-to-v1.mdx
+++ b/mdx/guides/migrate-0x-api-from-v0-to-v1.mdx
@@ -1,0 +1,15 @@
+# Migrate 0x API integrations from v0 to v1
+
+Upgrading from using 0x API `v0` to `v1` endpoints has many advantages such as better pricing and lower transaction costs. The new endpoints are mostly compatible with their `v0` equivalents but there are some notable changes to look out for.
+
+## Allowance target
+
+In `v0` ERC20 allowances were always set to the [ERC20Proxy contract](/docs/guides/v3-specification#assetproxy), as long as the user had an allowance set for that contract they were able to trade. In `v1` however, the ERC20 allowance target has changed and a new field `allowanceTarget` is introduced in the `/price` and `/quote` responses. The `allowanceTarget` field is the contract address that the user needs to set an ERC20 allowance for in order to be able to perform the trade. The allowance target address is subject to change in the future so make sure to use the address returned by 0x API rather than hard coding the current address. For any ERC20 -> ERC20 or ERC20 -> ETH trade an allowance must be set for `allowanceTarget`, for ETH -> ERC20, wrapping ETH into WETH, unwrapping WETH into ETH no allowance is required and `allowanceTarget` will be set to the null address `0x0000000000000000000000000000000000000000` in the API response.
+
+### A note regarding SRA endpoints
+
+The `/sra/*` endpoints and limit orders are not part of the `v1` upgrade and should continue to use [ERC20Proxy contract](/docs/guides/v3-specification#assetproxy) as the target contract for ERC20 allowances.
+
+## Support for quotes with buyToken ETH
+
+In `v0` it was not possible to request a quote for ERC20 -> ETH, only WETH was supported. With `v1` it is now fully supported to request quotes with `buyToken` ETH and the user will receive ETH.

--- a/mdx/guides/rfqt-in-the-0x-api.mdx
+++ b/mdx/guides/rfqt-in-the-0x-api.mdx
@@ -52,13 +52,13 @@ To alleviate this potential capital inefficiency, the RFQ-T model introduces the
 
 ## Indicative Pricing
 
-The indicative pricing resource is hosted at [`/swap/v0/price`](/docs/api#get-swapv0price) and responds with pricing information, but that response does not contain a full 0x order, so it does not constitute a legitimate transaction that can be submitted to the Ethereum network. Therefore, when a market maker services an indicative request they do not need to reserve any capital for it, leaving their capital available for other quotes to other clients.
+The indicative pricing resource is hosted at [`/swap/v1/price`](/docs/api#get-swapv1price) and responds with pricing information, but that response does not contain a full 0x order, so it does not constitute a legitimate transaction that can be submitted to the Ethereum network. Therefore, when a market maker services an indicative request they do not need to reserve any capital for it, leaving their capital available for other quotes to other clients.
 
 ## Firm Quotes
 
-The firm quote resource is hosted at [`/swap/v0/quote`](/docs/api#get-swapv0quote) and responds with a full 0x order, which can be submitted to an Ethereum node by the client. Therefore it is expected that the maker has reserved the maker assets required to settle the trade, leaving the order unlikely to revert.
+The firm quote resource is hosted at [`/swap/v1/quote`](/docs/api#get-swapv1quote) and responds with a full 0x order, which can be submitted to an Ethereum node by the client. Therefore it is expected that the maker has reserved the maker assets required to settle the trade, leaving the order unlikely to revert.
 
-Note that while the [`/price`](/docs/api#get-swapv0price) resource is new and specific to RFQ-T, the [`/quote`](/docs/api#get-swapv0quote) resource is the same one already used to access non-RFQ-T liquidity through the API. In order to qualify for RFQ-T liquidity, the request must include the query parameter `intentOnFilling=true` (in addition to the aforementioned `0x-api-key` and non-null `takerAddress`).
+Note that while the [`/price`](/docs/api#get-swapv1price) resource is new and specific to RFQ-T, the [`/quote`](/docs/api#get-swapv1quote) resource is the same one already used to access non-RFQ-T liquidity through the API. In order to qualify for RFQ-T liquidity, the request must include the query parameter `intentOnFilling=true` (in addition to the aforementioned `0x-api-key` and non-null `takerAddress`).
 
 ## When to Request Firm Quotes
 
@@ -139,7 +139,7 @@ Important note: A market maker should serve a unique order for each separate req
 
 ## Quote Validation
 
-Whenever a 0x API client specifies a `takerAddress` in their [`/quote`](/docs/api#get-swapv0quote) request, the API will validate the quote before returning it to the client, avoiding a number of possible causes for transaction reverts. (For more details, see ["How does `takerAddress` help with catching issues?"](/docs/guides/0x-api-faq#how-does-takeraddress-help-with-catching-issues).)
+Whenever a 0x API client specifies a `takerAddress` in their [`/quote`](/docs/api#get-swapv1quote) request, the API will validate the quote before returning it to the client, avoiding a number of possible causes for transaction reverts. (For more details, see ["How does `takerAddress` help with catching issues?"](/docs/guides/0x-api-faq#how-does-takeraddress-help-with-catching-issues).)
 
 However, given that a `takerAddress` is required in order to obtain RFQ-T liquidity, and given that this requirement subverts the optionality of the quote validation feature, the implementation of RFQ-T introduced a new query parameter to the `/quote` resource: `skipValidation`. When this parameter is set to `true`, quote validation will be skipped. While validating even RFQ-T quotes is a best-practice recommended default, skipping validation can be useful in certain circumstances, such as when experimenting with a new maker integration deployment.
 

--- a/mdx/guides/swap-tokens-with-0x-api.mdx
+++ b/mdx/guides/swap-tokens-with-0x-api.mdx
@@ -22,7 +22,7 @@ import * as qs from 'qs';
     }
     
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
     );
  
     await window.web3.eth.sendTransaction(await response.json());
@@ -47,14 +47,14 @@ import * as qs from 'qs';
     }
     
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
     );
     
     await window.web3.eth.sendTransaction(await response.json());
 })();
 ```
 
-Instead of specifying `buyAmount`, provide `sellAmount` in the params. If both are provided `sellAmount` is used over `buyAmount`. Refer to the [documentation](../api#get-swapv0quote) for more details.
+Instead of specifying `buyAmount`, provide `sellAmount` in the params. If both are provided `sellAmount` is used over `buyAmount`. Refer to the [documentation](../api#get-swapv1quote) for more details.
 
 
 ## Swap ERC20 token pairs
@@ -71,19 +71,7 @@ import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
 
 (async () => {
     const web3 = window.web3;
-    // Set up proxy approval
-    const USDCaddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-    const USDCcontract = new ERC20TokenContract(USDCaddress, web3.eth.currentProvider);
-    const maxApproval = new BigNumber(2).pow(256).minus(1);
 
-    // Send the approval to the 0x ERC20Proxy smart contract
-    const chainId = 1;
-    const contractAddresses = getContractAddressesForChainOrThrow(chainId);
-    const approvalTxData = USDCcontract
-        .approve(contractAddresses.erc20Proxy, maxApproval)
-        .getABIEncodedTransactionData();
-    await window.web3.eth.sendTransaction(approvalTxData);
-    
     // buying 1 DAI with USDC
     const params = {
         buyToken: 'DAI',
@@ -92,14 +80,26 @@ import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
     }
     
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
         );
+    const responseJson = await response.json()
+
+    // Set up proxy approval to allowanceTarget address provided in quote response
+    const USDCaddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const USDCcontract = new ERC20TokenContract(USDCaddress, web3.eth.currentProvider);
+    const maxApproval = new BigNumber(2).pow(256).minus(1);
+
+    // Send the approval to the 0x ERC20Proxy smart contract
+    const approvalTxData = USDCcontract
+        .approve(responseJson.allowanceTarget, maxApproval)
+        .getABIEncodedTransactionData();
+    await window.web3.eth.sendTransaction(approvalTxData);
     
-    await web3.eth.sendTransaction(await response.json());
+    await web3.eth.sendTransaction(responseJson);
 })();
 ```
 
-You can also request quotes with token addresses instead of symbols as `buyToken` or `sellToken`. Refer to the [documentation](../api#get-swapv0quote) for the full specification. 
+You can also request quotes with token addresses instead of symbols as `buyToken` or `sellToken`. Refer to the [documentation](../api#get-swapv1quote) for the full specification. 
 
 ## Specify a taker address for your swaps
 
@@ -120,7 +120,7 @@ import * as qs from 'qs';
     }
 
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
     );
     const responseJson = await response.json();
     if (response.ok) {
@@ -146,7 +146,7 @@ Here is a handy checklist to go through if you encounter reverts:
 
 ```typescript
 (async () => {
-    const response = await fetch('https://api.0x.org/swap/v0/tokens');
+    const response = await fetch('https://api.0x.org/swap/v1/tokens');
     const tokens = (await response.json()).records;
     console.log(`${JSON.stringify(tokens, null, 2)}`);
 })();
@@ -189,7 +189,7 @@ import * as qs from 'qs';
     }
 
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
     );
         
     const quote = await response.json();
@@ -247,7 +247,7 @@ import * as qs from 'qs';
             gasPrice,
         }
         const response = await fetch(
-            `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+            `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
         );
         const quote = await response.json();
     
@@ -283,7 +283,7 @@ import * as qs from 'qs';
     }
 
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
     );
 
     const quote = await response.json();
@@ -302,7 +302,7 @@ import * as qs from 'qs';
 
 ### Choosing liquidity sources
 
-With the `excludedSources` optional parameter in `swap/v0/quote`, you can specify which liquidity sources will not be used when providing a quote.
+With the `excludedSources` optional parameter in `swap/v1/quote`, you can specify which liquidity sources will not be used when providing a quote.
 
 ```javascript
 import qs from 'qs';
@@ -318,7 +318,7 @@ import qs from 'qs';
     }
 
     const response = await fetch(
-        `https://api.0x.org/swap/v0/quote?${qs.stringify(params)}`
+        `https://api.0x.org/swap/v1/quote?${qs.stringify(params)}`
     );
 
     const quote = await response.json();

--- a/mdx/guides/swap-tokens-with-0x-api.mdx
+++ b/mdx/guides/swap-tokens-with-0x-api.mdx
@@ -93,7 +93,7 @@ import { getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
     const approvalTxData = USDCcontract
         .approve(responseJson.allowanceTarget, maxApproval)
         .getABIEncodedTransactionData();
-    await window.web3.eth.sendTransaction(approvalTxData);
+    await window.web3.eth.sendTransaction({ to: USDCaddress, data: approvalTxData });
     
     await web3.eth.sendTransaction(responseJson);
 })();

--- a/mdx/guides/use-0x-api-liquidity-in-your-smart-contracts.mdx
+++ b/mdx/guides/use-0x-api-liquidity-in-your-smart-contracts.mdx
@@ -28,7 +28,7 @@ $ cd 0x-api-starter-guide-code
 $ npm install
 ```
 
-For development, we will be leveraging the Kovan test network and the respective kovan 0x api endpoint: `kovan.api.0x.org/swap/v0/quote`. 
+For development, we will be leveraging the Kovan test network and the respective kovan 0x api endpoint: `kovan.api.0x.org/swap/v1/quote`. 
 
 ### Configure the .env file
 
@@ -62,7 +62,7 @@ const params = {
     sellAmount: sellAmount.toString(),
 }
 
-const res = await fetch(`https://kovan.api.0x.org/swap/v0/quote?${qs.stringify(params)}`);
+const res = await fetch(`https://kovan.api.0x.org/swap/v1/quote?${qs.stringify(params)}`);
 const quote = await res.json();
 
 console.log('Received quote:', quote);

--- a/ts/pages/api.tsx
+++ b/ts/pages/api.tsx
@@ -55,7 +55,7 @@ const ZeroExApi: React.FC<ApiPageProps> = () => {
     const formattedTakerAmount = takerAmount.dividedToIntegerBy(1).toString();
 
     const API_BASE = utils.getAPIBaseUrl(networkId || 1);
-    const quoteEndpoint = `${API_BASE}/swap/v0/quote?sellAmount=${formattedTakerAmount}&buyToken=DAI&sellToken=USDC`;
+    const quoteEndpoint = `${API_BASE}/swap/v1/quote?sellAmount=${formattedTakerAmount}&buyToken=DAI&sellToken=USDC`;
     // Surround endpoint in quotes so users can directly curl this (otherwise the ampersands escape out when pasting into terminal)
     const copyableQuoteEndpoint = `"${quoteEndpoint}"`;
 
@@ -237,7 +237,7 @@ const ZeroExApi: React.FC<ApiPageProps> = () => {
                         <RequestEndpointRow>
                             <EndpointLabel>
                                 <CurlEndpointLabel>curl </CurlEndpointLabel>
-                                <CurlEndpointText> https://api.0x.org/swap/v0/quote</CurlEndpointText>
+                                <CurlEndpointText> https://api.0x.org/swap/v1/quote</CurlEndpointText>
                             </EndpointLabel>
                         </RequestEndpointRow>
                         <RequestConfigurationRow>
@@ -283,7 +283,7 @@ const ZeroExApi: React.FC<ApiPageProps> = () => {
                                     <Button
                                         fontSize={'16px'}
                                         target={'_blank'}
-                                        href="https://codepen.io/fragosti/pen/xxbmgqy"
+                                        href="https://codepen.io/kimpers/pen/zYqMdxE"
                                         isWithArrow={true}
                                         isAccentColor={true}
                                     >
@@ -300,7 +300,7 @@ const ZeroExApi: React.FC<ApiPageProps> = () => {
                                 >
                                     {`// Get a quote to sell 1 ETH to buy DAI
 const response = await fetch(
-  'https://api.0x.org/swap/v0/quote?sellToken=ETH&buyToken=DAI&sellAmount=1000000000000000000'
+  'https://api.0x.org/swap/v1/quote?sellToken=ETH&buyToken=DAI&sellAmount=1000000000000000000'
 );
 const quote = await response.json();
 // Send to ethereum with your favorite Web3 Library
@@ -357,9 +357,7 @@ window.web3.eth.sendTransaction(quote, (err, txId) => {
                     <ExampleRowContainer>
                         <ExampleLeftContainer>
                             <ExampleLabel>Margin trading with 0x API</ExampleLabel>
-                            <ExampleDescription>
-                                Create a margin trading DeFi product using 0x API
-                            </ExampleDescription>
+                            <ExampleDescription>Create a margin trading DeFi product using 0x API</ExampleDescription>
                         </ExampleLeftContainer>
                         <ExampleLink>
                             <Button

--- a/ts/pages/docs/home.tsx
+++ b/ts/pages/docs/home.tsx
@@ -75,7 +75,7 @@ const usefulLinks = [
 const getStartedLinks = [
     {
         heading: 'Swap Tokens With 0x API',
-        description: 'Learn how to complete a token swap with 0x API /swap/v0/* endpoint.',
+        description: 'Learn how to complete a token swap with 0x API /swap/v1/* endpoint.',
         url: `${WebsitePaths.DocsGuides}/swap-tokens-with-0x-api`,
     },
     {

--- a/ts/utils/algolia_meta.json
+++ b/ts/utils/algolia_meta.json
@@ -29,8 +29,8 @@
         },
         "swap-tokens-with-0x-api": {
             "title": "Swap Tokens With 0x API",
-            "subtitle": "Learn how to complete a token swap with 0x API /swap/v0/* endpoints",
-            "description": "Learn how to complete a token swap with 0x API /swap/v0/* endpoints",
+            "subtitle": "Learn how to complete a token swap with 0x API /swap/v1/* endpoints",
+            "description": "Learn how to complete a token swap with 0x API /swap/v1/* endpoints",
             "tags": ["0x API"],
             "topics": ["0x API"],
             "difficulty": "Beginner",
@@ -175,12 +175,7 @@
             "title": "0x Coordinator Specification (v2)",
             "description": "A comprehensive technical spec of the first coordinator model developer by the 0x core team (soft-cancel variant)",
             "tags": ["Coordinator", "Relayer", "Trader", "Protocol Developer"],
-            "topics": [
-                "Coordinator",
-                "Relayer",
-                "Trader",
-                "Protocol Developer"
-            ],
+            "topics": ["Coordinator", "Relayer", "Trader", "Protocol Developer"],
             "difficulty": "Advanced",
             "path": "guides/v2-coordinator-specification.mdx"
         },
@@ -228,40 +223,16 @@
         "v3-staking-specification": {
             "title": "0x Staking Specification (v3)",
             "description": "The technical spec for the Staking in 0x protocol v3. Allowing Market Makers to receive rebates when orders are filled.",
-            "tags": [
-                "Specs",
-                "Relayer",
-                "Trader",
-                "Market Maker",
-                "Protocol Developer"
-            ],
-            "topics": [
-                "Specs",
-                "Relayer",
-                "Trader",
-                "Market Maker",
-                "Protocol Developer"
-            ],
+            "tags": ["Specs", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
+            "topics": ["Specs", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
             "difficulty": "Advanced",
             "path": "guides/v3-staking-specification.mdx"
         },
         "v3-coordinator-specification": {
             "title": "0x Coordinator Specification (v3)",
             "description": "A comprehensive technical spec of the first coordinator model developer by the 0x core team (soft-cancel variant)",
-            "tags": [
-                "Coordinator",
-                "Relayer",
-                "Trader",
-                "Market Maker",
-                "Protocol Developer"
-            ],
-            "topics": [
-                "Coordinator",
-                "Relayer",
-                "Trader",
-                "Market Maker",
-                "Protocol Developer"
-            ],
+            "tags": ["Coordinator", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
+            "topics": ["Coordinator", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
             "difficulty": "Advanced",
             "path": "guides/v3-coordinator-specification.mdx"
         },

--- a/ts/utils/algolia_meta.json
+++ b/ts/utils/algolia_meta.json
@@ -18,6 +18,15 @@
         }
     },
     "guides": {
+        "migrate-0x-api-from-v0-to-v1": {
+            "title": "Migrate 0x API integrations from the v0 to v1 endpoints",
+            "subtitle": "Learn how to migrate your existing 0x API integration to use the v1 endpoints",
+            "description": "Learn how to migrate your existing 0x API integration to use the v1 endpoints",
+            "tags": ["0x API"],
+            "topics": ["0x API"],
+            "difficulty": "Intermediate",
+            "path": "guides/migrate-0x-api-from-v0-to-v1.mdx"
+        },
         "develop-a-margin-trading-smart-contract-with-0x-api": {
             "title": "Develop a margin trading smart contract with 0x API",
             "subtitle": "Develop a contract to leverage Eth with Compound Finance + 0x API",
@@ -175,7 +184,12 @@
             "title": "0x Coordinator Specification (v2)",
             "description": "A comprehensive technical spec of the first coordinator model developer by the 0x core team (soft-cancel variant)",
             "tags": ["Coordinator", "Relayer", "Trader", "Protocol Developer"],
-            "topics": ["Coordinator", "Relayer", "Trader", "Protocol Developer"],
+            "topics": [
+                "Coordinator",
+                "Relayer",
+                "Trader",
+                "Protocol Developer"
+            ],
             "difficulty": "Advanced",
             "path": "guides/v2-coordinator-specification.mdx"
         },
@@ -223,16 +237,40 @@
         "v3-staking-specification": {
             "title": "0x Staking Specification (v3)",
             "description": "The technical spec for the Staking in 0x protocol v3. Allowing Market Makers to receive rebates when orders are filled.",
-            "tags": ["Specs", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
-            "topics": ["Specs", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
+            "tags": [
+                "Specs",
+                "Relayer",
+                "Trader",
+                "Market Maker",
+                "Protocol Developer"
+            ],
+            "topics": [
+                "Specs",
+                "Relayer",
+                "Trader",
+                "Market Maker",
+                "Protocol Developer"
+            ],
             "difficulty": "Advanced",
             "path": "guides/v3-staking-specification.mdx"
         },
         "v3-coordinator-specification": {
             "title": "0x Coordinator Specification (v3)",
             "description": "A comprehensive technical spec of the first coordinator model developer by the 0x core team (soft-cancel variant)",
-            "tags": ["Coordinator", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
-            "topics": ["Coordinator", "Relayer", "Trader", "Market Maker", "Protocol Developer"],
+            "tags": [
+                "Coordinator",
+                "Relayer",
+                "Trader",
+                "Market Maker",
+                "Protocol Developer"
+            ],
+            "topics": [
+                "Coordinator",
+                "Relayer",
+                "Trader",
+                "Market Maker",
+                "Protocol Developer"
+            ],
             "difficulty": "Advanced",
             "path": "guides/v3-coordinator-specification.mdx"
         },
@@ -306,8 +344,8 @@
             "isFeatured": false,
             "tags": ["Trader", "Protocol Developer"],
             "type": "Typescript Libraries",
-            "path": "tools/@0x/asset-swapper/v4.5.0/reference.mdx",
-            "versions": ["v4.5.0", "v4.4.0"]
+            "path": "tools/@0x/asset-swapper/v4.6.0/reference.mdx",
+            "versions": ["v4.6.0"]
         },
         "0x.js": {
             "title": "0x.js",
@@ -317,8 +355,8 @@
             "isFeatured": false,
             "tags": ["Trader", "Relayer", "Protocol Developer"],
             "type": "Typescript Libraries",
-            "path": "tools/0x.js/v9.1.6/reference.mdx",
-            "versions": ["v9.1.6", "v9.1.5"]
+            "path": "tools/0x.js/v9.2.0/reference.mdx",
+            "versions": ["v9.2.0"]
         },
         "connect": {
             "title": "0x Connect",
@@ -328,8 +366,8 @@
             "isFeatured": false,
             "tags": ["Trader", "Relayer"],
             "type": "Typescript Libraries",
-            "path": "tools/@0x/connect/v6.0.8/reference.mdx",
-            "versions": ["v6.0.8", "v6.0.7"]
+            "path": "tools/@0x/connect/v6.0.9/reference.mdx",
+            "versions": ["v6.0.9"]
         },
         "subproviders": {
             "title": "Subproviders",
@@ -339,8 +377,8 @@
             "isFeatured": false,
             "tags": ["Relayer", "Trader"],
             "type": "Typescript Libraries",
-            "path": "tools/@0x/subproviders/v6.1.0/reference.mdx",
-            "versions": ["v6.1.0", "v6.0.8"]
+            "path": "tools/@0x/subproviders/v6.1.1/reference.mdx",
+            "versions": ["v6.1.1"]
         },
         "contract-wrappers": {
             "title": "0x Contract Wrappers",
@@ -350,8 +388,8 @@
             "isFeatured": false,
             "tags": ["Trader", "Relayer"],
             "type": "Typescript Libraries",
-            "path": "tools/@0x/contract-wrappers/v13.7.0/reference.mdx",
-            "versions": ["v13.7.0", "v13.6.3"]
+            "path": "tools/@0x/contract-wrappers/v13.8.0/reference.mdx",
+            "versions": ["v13.8.0"]
         },
         "json-schemas": {
             "title": "0x JSON Schemas",
@@ -362,8 +400,8 @@
             "tags": ["Trader", "Relayer"],
             "type": "Typescript Libraries",
             "isHidden": true,
-            "path": "tools/@0x/json-schemas/v5.0.8/reference.mdx",
-            "versions": ["v5.0.8", "v5.0.7"]
+            "path": "tools/@0x/json-schemas/v5.1.0/reference.mdx",
+            "versions": ["v5.1.0"]
         },
         "order-utils": {
             "title": "0x Order Utils",
@@ -374,8 +412,8 @@
             "tags": ["Trader", "Relayer"],
             "type": "Typescript Libraries",
             "isHidden": true,
-            "path": "tools/@0x/order-utils/v10.2.5/reference.mdx",
-            "versions": ["v10.2.5", "v10.2.4"]
+            "path": "tools/@0x/order-utils/v10.3.0/reference.mdx",
+            "versions": ["v10.3.0"]
         },
         "sol-compiler": {
             "title": "sol-compiler",
@@ -386,8 +424,8 @@
             "tags": ["Protocol Developer"],
             "type": "Typescript Libraries",
             "isHidden": true,
-            "path": "tools/@0x/sol-compiler/v4.1.0/reference.mdx",
-            "versions": ["v4.1.0", "v4.0.8"]
+            "path": "tools/@0x/sol-compiler/v4.1.1/reference.mdx",
+            "versions": ["v4.1.1"]
         },
         "sol-coverage": {
             "title": "sol-coverage",
@@ -399,8 +437,8 @@
             "tags": ["Protocol Developer"],
             "type": "Typescript Libraries",
             "isHidden": true,
-            "path": "tools/@0x/sol-coverage/v4.0.9/reference.mdx",
-            "versions": ["v4.0.9", "v4.0.8"]
+            "path": "tools/@0x/sol-coverage/v4.0.10/reference.mdx",
+            "versions": ["v4.0.10"]
         },
         "sol-profiler": {
             "title": "sol-profiler",
@@ -412,8 +450,8 @@
             "tags": ["Protocol Developer"],
             "type": "Typescript Libraries",
             "isHidden": true,
-            "path": "tools/@0x/sol-profiler/v4.0.9/reference.mdx",
-            "versions": ["v4.0.9", "v4.0.8"]
+            "path": "tools/@0x/sol-profiler/v4.1.0/reference.mdx",
+            "versions": ["v4.1.0"]
         },
         "sol-trace": {
             "title": "sol-trace",
@@ -425,8 +463,8 @@
             "tags": ["Protocol Developer"],
             "type": "Typescript Libraries",
             "isHidden": true,
-            "path": "tools/@0x/sol-trace/v3.0.9/reference.mdx",
-            "versions": ["v3.0.9", "v3.0.8"]
+            "path": "tools/@0x/sol-trace/v3.0.10/reference.mdx",
+            "versions": ["v3.0.10"]
         },
         "mesh-ts-client": {
             "title": "TS/JS Mesh RPC Client",
@@ -586,8 +624,8 @@
             "isFeatured": false,
             "tags": ["Protocol Developer", "Relayer"],
             "type": "CLI",
-            "path": "tools/@0x/migrations/v6.3.0/reference.mdx",
-            "versions": ["v6.3.0", "v6.2.4"]
+            "path": "tools/@0x/migrations/v6.4.0/reference.mdx",
+            "versions": ["v6.4.0"]
         },
         "launch-kit-wizard": {
             "title": "Launch Kit Wizard",


### PR DESCRIPTION
This updates the current documentation and guides to be valid for the 0x API `v1` endpoints and adds a basic migration guide for how to successfully migrate from using `v0` to `v1` endpoints. 

Depends on 0xProject/0x-api#361 for `v1` endpoint parity.