### PR TITLE
changed misleading 0x intro guide

### DIFF
--- a/mdx/guides/introduction-to-using-0x-liquidity-in-smart-contracts.mdx
+++ b/mdx/guides/introduction-to-using-0x-liquidity-in-smart-contracts.mdx
@@ -23,11 +23,11 @@ In addition, [0x API](/docs/api) offers an easy-to-use interface for accessing t
 
 ### Networked Liquidity: sharing orders with the world
 
-An order involves two parties: a maker, who creates and signs the order; and a taker, who fills the order. For takers to find the best prices, they need to have access to the most possible orders. 0x Mesh is a P2P protocol that functions as a decentralized global network for sharing orders, including orders from Kyber, Uniswap, Oasis, and more. This results in a massive pool of “networked liquidity”. Unlike the fragmented nature of traditional centralized financial exchanges, networked liquidity guarantees takers are getting the best price available.
+An order involves two parties: a maker, who creates and signs the order; and a taker, who fills the order. For takers to find the best prices, they need to have access to the most possible orders. 0x Mesh is a P2P protocol that functions as a decentralized global network for sharing 0x orders. This results in a massive pool of “networked liquidity”. Unlike the fragmented nature of traditional centralized financial exchanges, networked liquidity guarantees takers are getting the best price available.
 
 ### 0x API: A one-step interface to networked liquidity
 
-Any user can interact directly with the 0x Mesh network. However, the lower-level nature of the P2P protocol has a steeper learning curve to fully leverage it. 0x API offers a high-level interface to consume networked liquidity from 0x Mesh and other DEX aggregators. A simple HTTP request allows potential takers to obtain available orders (quotes) for the best prices on the network for swapping their desired tokens.
+Any user can interact directly with the 0x Mesh network. However, the lower-level nature of the P2P protocol has a steeper learning curve to fully leverage it. 0x API offers a high-level interface to consume networked liquidity from 0x Mesh and other onchain liquidity sources, such as Uniswap and Kyber. A simple HTTP request allows potential takers to obtain available orders (quotes) for the best prices on the network for swapping their desired tokens.
 
 ### Fill 0x orders from your smart contract
 


### PR DESCRIPTION
Fixed a couple of misleading sentences in the https://0x.org/docs/guides/introduction-to-using-0x-liquidity-in-smart-contracts guide after a user on Discord raised questions