### PR TITLE
fix: point the RFQT link on homepage to the right location

### DIFF
--- a/ts/components/sections/landing/about.tsx
+++ b/ts/components/sections/landing/about.tsx
@@ -81,7 +81,7 @@ export const SectionLandingAbout = () => {
                                     Offer competitive pricing through{' '}
                                     <span style={{ color: '#00AE99' }}>
                                         <Link
-                                            href={`/docs/api#an-exclusive-source-of-liquidity`}
+                                            href={`/docs/guides/rfqt-in-the-0x-api`}
                                             isNoArrow={true}
                                             isBlock={false}
                                             shouldOpenInNewTab={true}


### PR DESCRIPTION
RFQT link is stale, updating to the proper link