### PR TITLE
[Hotfix] Not Enough ETH

### DIFF
--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components';
 import { Button } from 'ts/components/button';
 import { CallToAction } from 'ts/components/call_to_action';
 import { ChangePoolDialog } from 'ts/components/staking/change_pool_dialog';
-import { ErrorModal } from 'ts/pages/governance/error_modal';
 import { StakingPageLayout } from 'ts/components/staking/layout/staking_page_layout';
 import { RemoveStakeDialog } from 'ts/components/staking/remove_stake_dialog';
 import { Heading, Paragraph } from 'ts/components/text';
@@ -29,6 +28,7 @@ import {
     AccountSelfVotingPowerOverview,
     AccountVotingPowerOverview,
 } from 'ts/pages/account/account_voting_power_overview';
+import { ErrorModal } from 'ts/pages/governance/error_modal';
 import { Dispatcher } from 'ts/redux/dispatcher';
 import { State } from 'ts/redux/reducer';
 import { colors } from 'ts/style/colors';
@@ -123,7 +123,6 @@ export const Account: React.FC<AccountProps> = () => {
     // NOTE: not yet implemented but left in for future reference
     const voteHistory: VoteHistory[] = [];
 
-    const [isErrorModalOpen, setErrorModalOpen] = React.useState(false);
     const [stakingError, setStakingError] = React.useState<Error | undefined>(undefined);
     const [isApplyModalOpen, toggleApplyModal] = React.useState(false);
     const [changePoolDetails, setChangePoolDetails] = React.useState<PoolDetails | undefined>(undefined);

--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -150,10 +150,15 @@ export const Account: React.FC<AccountProps> = () => {
     const [pendingUnstakePoolSet, setPendingUnstakePoolSet] = React.useState<Set<string>>(new Set());
 
     const apiClient = useAPIClient(networkId);
-    const { stakingContract, unstake, withdrawStake, withdrawRewards, moveStake, currentEpochRewards, error: useStakeError } = useStake(
-        networkId,
-        providerState,
-    );
+    const {
+        stakingContract,
+        unstake,
+        withdrawStake,
+        withdrawRewards,
+        moveStake,
+        currentEpochRewards,
+        error: useStakeError,
+    } = useStake(networkId, providerState);
 
     const hasDataLoaded = () => Boolean(delegatorData && poolWithStatsMap && availableRewardsMap);
     const hasRewards = () => Boolean(allTimeRewards.isGreaterThan(0) || expectedCurrentEpochRewards.isGreaterThan(0));
@@ -396,7 +401,7 @@ export const Account: React.FC<AccountProps> = () => {
         if (useStakeError) {
             setStakingError(useStakeError);
         }
-    }, [useStakeError])
+    }, [useStakeError]);
 
     const accountLoaded = account && account.address;
 
@@ -778,10 +783,16 @@ export const Account: React.FC<AccountProps> = () => {
                     });
                 }}
             />
-            <ErrorModal isOpen={Boolean(stakingError)} text={'More ETH is required to complete this transaction. Fund your wallet and try again.'} heading={'Insufficient ETH'} buttonText={'Dismiss'} onClose={() => {
-                setStakingError(undefined);
-            }} />
-       
+            <ErrorModal
+                isOpen={Boolean(stakingError)}
+                text={'More ETH is required to complete this transaction. Fund your wallet and try again.'}
+                heading={'Insufficient ETH'}
+                buttonText={'Dismiss'}
+                onClose={() => {
+                    setStakingError(undefined);
+                }}
+            />
+
             <DialogOverlay
                 style={{ background: 'rgba(0, 0, 0, 0.75)', zIndex: 30 }}
                 isOpen={shouldOpenStakeDecisionModal}

--- a/ts/pages/governance/error_modal.tsx
+++ b/ts/pages/governance/error_modal.tsx
@@ -46,7 +46,7 @@ ErrorModal.defaultProps = {
 };
 
 const Wrapper = styled.div<ErrorModalProps>`
-    position: absolute;
+    position: fixed;
     background-color: rgba(0, 0, 0, 0.75);
     display: flex;
     top: 0;
@@ -55,6 +55,7 @@ const Wrapper = styled.div<ErrorModalProps>`
     bottom: 0;
     opacity: 0;
     visibility: hidden;
+    z-index: 30;
 
     ${(props) =>
         props.isOpen &&
@@ -69,7 +70,6 @@ const Inner = styled.div`
     background-color: #f6f6f6;
     padding: 30px 30px;
     width: 440px;
-    height: 440px;
     text-align: center;
 `;
 
@@ -79,7 +79,6 @@ const ErrorBox = styled.div`
     padding: 18px 30px;
     margin-bottom: 30px;
     overflow: auto;
-    max-height: 95px;
 `;
 
 const Text = styled(Paragraph).attrs({


### PR DESCRIPTION
Currently, when your wallet doesn't have enough eth for a staking related txn, the error is handled silently, which is bad UX/UI for the user. This hotfix repurposes the governance error modal to be used to show the user when their txn attempt fails b/c they do not have enough ETH in there wallet.