### PR TITLE
Hotfix: Add a link to external protocol docs [TKR-78]

### DIFF
--- a/ts/components/docs/header/header.tsx
+++ b/ts/components/docs/header/header.tsx
@@ -56,6 +56,11 @@ const navItems: INavItems[] = [
         text: 'Tools',
         url: WebsitePaths.DocsTools,
     },
+    {
+        id: 'contracts',
+        text: 'Contracts',
+        url: 'https://protocol.0x.org/en/latest/',
+    },
 ];
 
 export const Header: React.FC<IHeaderProps> = ({ isNavToggled, toggleMobileNav }) => {


### PR DESCRIPTION
Just a patch to make Protocol docs more discoverable for now. 
Added a single new link `Contracts` to the header bar, directs to https://protocol.0x.org/en/latest/

![Screen Shot 2021-05-17 at 1 54 49 PM](https://user-images.githubusercontent.com/8582774/118555791-ef308f80-b717-11eb-9894-89aba44db22c.png)
