### PR TITLE
fix: Fix NaN staking rewards and 'Rebalance Stake' button with no stake

### DIFF
--- a/ts/pages/account/dashboard.tsx
+++ b/ts/pages/account/dashboard.tsx
@@ -290,7 +290,9 @@ export const Account: React.FC<AccountProps> = () => {
             setCurrentEpochStakeMap(_currentEpochStakeMap);
             setNextEpochStakeMap(_nextEpochStakeMap);
             setAllTimeRewards(_allTimeRewards);
-            setExpectedCurrentEpochRewards(_expectedCurrentEpochRewards);
+            setExpectedCurrentEpochRewards(
+                _expectedCurrentEpochRewards.isNaN() ? new BigNumber(0) : _expectedCurrentEpochRewards,
+            );
             setVotingPowerMap(_votingPowerMap);
             setHasVotingPower(doesUserHaveVotingPower);
         };
@@ -707,21 +709,27 @@ export const Account: React.FC<AccountProps> = () => {
                                 );
                             })
                     )}
-                    <div
-                        style={{
-                            alignSelf: 'flex-end',
-                            margin: '1rem 0',
-                        }}
-                    >
-                        <Button
-                            color={colors.white}
-                            onClick={() => {
-                                setIsRebalanceOpen(true);
-                            }}
-                        >
-                            Rebalance Stake
-                        </Button>
-                    </div>
+                    {
+                        // Only show the "Rebalance Stake" button if there is at least one stake pool
+                        // for the current epoch
+                        poolData.length && (
+                            <div
+                                style={{
+                                    alignSelf: 'flex-end',
+                                    margin: '1rem 0',
+                                }}
+                            >
+                                <Button
+                                    color={colors.white}
+                                    onClick={() => {
+                                        setIsRebalanceOpen(true);
+                                    }}
+                                >
+                                    Rebalance Stake
+                                </Button>
+                            </div>
+                        )
+                    }
                 </SectionWrapper>
             )}
             {hasDataLoaded() && hasVotingPower && (


### PR DESCRIPTION
- Fix estimated awards for epoch showing "NaN" (now shows 0)
- Hide "Rebalance Stake" button when staked amount is zero.
<img width="547" alt="Screen Shot 2021-10-26 at 12 00 16 PM" src="https://user-images.githubusercontent.com/5778036/138960737-61310784-72d6-46d4-855b-c4f403d4149c.png">
<img width="1237" alt="Screen Shot 2021-10-26 at 12 31 34 PM" src="https://user-images.githubusercontent.com/5778036/138960748-fb737281-7424-41cb-9600-d58e6b4f8eaf.png">


