### PR TITLE
Add two new v4 NFT docs

### DIFF
--- a/mdx/guides/0x-v4-nft-contract-interfaces.mdx
+++ b/mdx/guides/0x-v4-nft-contract-interfaces.mdx
@@ -1,0 +1,543 @@
+# 0x V4 NFT Contract Interfaces
+
+## Order Formats
+
+```
+enum TradeDirection {
+    SELL_NFT,
+    BUY_NFT
+}
+
+struct Property {
+    IPropertyValidator propertyValidator;
+    bytes propertyData;
+}
+
+struct Fee {
+    address recipient;
+    uint256 amount;
+    bytes feeData;
+}
+
+struct ERC721Order {
+    TradeDirection direction;
+    address maker;
+    address taker;
+    uint256 expiry;
+    uint256 nonce;
+    IERC20TokenV06 erc20Token;
+    uint256 erc20TokenAmount;
+    Fee[] fees;
+    IERC721Token erc721Token;
+    uint256 erc721TokenId;
+    Property[] erc721TokenProperties;
+}
+
+struct ERC1155Order {
+    TradeDirection direction;
+    address maker;
+    address taker;
+    uint256 expiry;
+    uint256 nonce;
+    IERC20TokenV06 erc20Token;
+    uint256 erc20TokenAmount;
+    Fee[] fees;
+    IERC1155Token erc1155Token;
+    uint256 erc1155TokenId;
+    Property[] erc1155TokenProperties;
+    uint128 erc1155TokenAmount;
+}
+```
+
+## ERC721 Orders
+
+### Basic Functionality
+
+```
+/// @dev Sells an ERC721 asset to fill the given order.
+/// @param buyOrder The ERC721 buy order.
+/// @param signature The order signature from the maker.
+/// @param erc721TokenId The ID of the ERC721 asset being
+///        sold. If the given order specifies properties,
+///        the asset must satisfy those properties. Otherwise,
+///        it must equal the tokenId in the order.
+/// @param unwrapNativeToken If this parameter is true and the
+///        ERC20 token of the order is e.g. WETH, unwraps the
+///        token before transferring it to the taker.
+/// @param callbackData If this parameter is non-zero, invokes
+///        `zeroExERC721OrderCallback` on `msg.sender` after
+///        the ERC20 tokens have been transferred to `msg.sender`
+///        but before transferring the ERC721 asset to the buyer.
+function sellERC721(
+    LibNFTOrder.ERC721Order _calldata_ buyOrder,
+    LibSignature.Signature _calldata_ signature,
+    uint256 erc721TokenId,
+    bool unwrapNativeToken,
+    bytes _calldata_ callbackData
+)
+    _external_;
+    
+/// @dev Buys an ERC721 asset by filling the given order.
+/// @param sellOrder The ERC721 sell order.
+/// @param signature The order signature.
+/// @param callbackData If this parameter is non-zero, invokes
+///        `zeroExERC721OrderCallback` on `msg.sender` after
+///        the ERC721 asset has been transferred to `msg.sender`
+///        but before transferring the ERC20 tokens to the seller.
+///        Native tokens acquired during the callback can be used
+///        to fill the order.
+function buyERC721(
+    LibNFTOrder.ERC721Order _calldata_ sellOrder,
+    LibSignature.Signature _calldata_ signature,
+    bytes _calldata_ callbackData
+)
+    _external_
+    _payable_;
+    
+/// @dev Cancel a single ERC721 order by its nonce. The caller
+///      should be the maker of the order. Silently succeeds if
+///      an order with the same nonce has already been filled or
+///      cancelled.
+/// @param orderNonce The order nonce.
+function cancelERC721Order(uint256 orderNonce)
+    _external_;
+```
+
+### Advanced Functionality
+
+```
+/// @dev Cancel multiple ERC721 orders by their nonces. The caller
+///      should be the maker of the orders. Silently succeeds if
+///      an order with the same nonce has already been filled or
+///      cancelled.
+/// @param orderNonces The order nonces.
+function batchCancelERC721Orders(uint256[] _calldata_ orderNonces)
+    _external_;
+    
+/// @dev Buys multiple ERC721 assets by filling the
+///      given orders.
+/// @param sellOrders The ERC721 sell orders.
+/// @param signatures The order signatures.
+/// @param revertIfIncomplete If true, reverts if this
+///        function fails to fill any individual order.
+/// @return successes An array of booleans corresponding to whether
+///         each order in `orders` was successfully filled.
+function batchBuyERC721s(
+    LibNFTOrder.ERC721Order[] _calldata_ sellOrders,
+    LibSignature.Signature[] _calldata_ signatures,
+    bool revertIfIncomplete
+)
+    _external_
+    _payable_
+    returns (bool[] _memory_ successes);
+    
+/// @dev Matches a pair of complementary orders that have
+///      a non-negative spread. Each order is filled at
+///      their respective price, and the matcher receives
+///      a profit denominated in the ERC20 token.
+/// @param sellOrder Order selling an ERC721 asset.
+/// @param buyOrder Order buying an ERC721 asset.
+/// @param sellOrderSignature Signature for the sell order.
+/// @param buyOrderSignature Signature for the buy order.
+/// @return profit The amount of profit earned by the caller
+///         of this function (denominated in the ERC20 token
+///         of the matched orders).
+function matchERC721Orders(
+    LibNFTOrder.ERC721Order _calldata_ sellOrder,
+    LibNFTOrder.ERC721Order _calldata_ buyOrder,
+    LibSignature.Signature _calldata_ sellOrderSignature,
+    LibSignature.Signature _calldata_ buyOrderSignature
+)
+    _external_
+    returns (uint256 profit);
+    
+/// @dev Matches pairs of complementary orders that have
+///      non-negative spreads. Each order is filled at
+///      their respective price, and the matcher receives
+///      a profit denominated in the ERC20 token.
+/// @param sellOrders Orders selling ERC721 assets.
+/// @param buyOrders Orders buying ERC721 assets.
+/// @param sellOrderSignatures Signatures for the sell orders.
+/// @param buyOrderSignatures Signatures for the buy orders.
+/// @return profits The amount of profit earned by the caller
+///         of this function for each pair of matched orders
+///         (denominated in the ERC20 token of the order pair).
+/// @return successes An array of booleans corresponding to
+///         whether each pair of orders was successfully matched.
+function batchMatchERC721Orders(
+    LibNFTOrder.ERC721Order[] _calldata_ sellOrders,
+    LibNFTOrder.ERC721Order[] _calldata_ buyOrders,
+    LibSignature.Signature[] _calldata_ sellOrderSignatures,
+    LibSignature.Signature[] _calldata_ buyOrderSignatures
+)
+    _external_
+    returns (uint256[] _memory_ profits, bool[] _memory_ successes);
+    
+/// @dev Callback for the ERC721 `safeTransferFrom` function.
+///      This callback can be used to sell an ERC721 asset if
+///      a valid ERC721 order, signature and `unwrapNativeToken`
+///      are encoded in `data`. This allows takers to sell their
+///      ERC721 asset without first calling `setApprovalForAll`.
+/// @param operator The address which called `safeTransferFrom`.
+/// @param from The address which previously owned the token.
+/// @param tokenId The ID of the asset being transferred.
+/// @param data Additional data with no specified format. If a
+///        valid ERC721 order, signature and `unwrapNativeToken`
+///        are encoded in `data`, this function will try to fill
+///        the order using the received asset.
+/// @return success The selector of this function (0x150b7a02),
+///         indicating that the callback succeeded.
+function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes _calldata_ data
+)
+    _external_
+    returns (bytes4 success);
+    
+/// @dev Approves an ERC721 order on-chain. After pre-signing
+///      the order, the `PRESIGNED` signature type will become
+///      valid for that order and signer.
+/// @param order An ERC721 order.
+function preSignERC721Order(LibNFTOrder.ERC721Order _calldata_ order)
+    _external_;        
+```
+
+### Read-only Functions
+
+```
+/// @dev Checks whether the given signature is valid for the
+///      the given ERC721 order. Reverts if not.
+/// @param order The ERC721 order.
+/// @param signature The signature to validate.
+function validateERC721OrderSignature(
+    LibNFTOrder.ERC721Order _calldata_ order,
+    LibSignature.Signature _calldata_ signature
+)
+    _external_
+    _view_;
+    
+/// @dev If the given order is buying an ERC721 asset, checks
+///      whether or not the given token ID satisfies the required
+///      properties specified in the order. If the order does not
+///      specify any properties, this function instead checks
+///      whether the given token ID matches the ID in the order.
+///      Reverts if any checks fail, or if the order is selling
+///      an ERC721 asset.
+/// @param order The ERC721 order.
+/// @param erc721TokenId The ID of the ERC721 asset.
+function validateERC721OrderProperties(
+    LibNFTOrder.ERC721Order _calldata_ order,
+    uint256 erc721TokenId
+)
+    _external_
+    _view_;
+    
+/// @dev Get the current status of an ERC721 order.
+/// @param order The ERC721 order.
+/// @return status The status of the order.
+function getERC721OrderStatus(LibNFTOrder.ERC721Order _calldata_ order)
+    _external_
+    _view_
+    returns (LibNFTOrder.OrderStatus status);
+    
+/// @dev Get the canonical hash of an ERC721 order.
+/// @param order The ERC721 order.
+/// @return orderHash The order hash.
+function getERC721OrderHash(LibNFTOrder.ERC721Order _calldata_ order)
+    _external_
+    _view_
+    returns (bytes32 orderHash);
+    
+/// @dev Get the order status bit vector for the given
+///      maker address and nonce range.
+/// @param maker The maker of the order.
+/// @param nonceRange Order status bit vectors are indexed
+///        by maker address and the upper 248 bits of the
+///        order nonce. We define `nonceRange` to be these
+///        248 bits.
+/// @return bitVector The order status bit vector for the
+///         given maker and nonce range.
+function getERC721OrderStatusBitVector(address maker, uint248 nonceRange)
+    _external_
+    _view_
+    returns (uint256 bitVector);
+```
+
+### Events
+
+```
+/// @dev Emitted whenever an `ERC1155Order` is filled.
+/// @param direction Whether the order is selling or
+///        buying the ERC1155 token.
+/// @param maker The maker of the order.
+/// @param taker The taker of the order.
+/// @param nonce The unique maker nonce in the order.
+/// @param erc20Token The address of the ERC20 token.
+/// @param erc20FillAmount The amount of ERC20 token filled.
+/// @param erc1155Token The address of the ERC1155 token.
+/// @param erc1155TokenId The ID of the ERC1155 asset.
+/// @param erc1155FillAmount The amount of ERC1155 asset filled.
+/// @param matcher Currently unused.
+event ERC1155OrderFilled(
+    LibNFTOrder.TradeDirection direction,
+    address maker,
+    address taker,
+    uint256 nonce,
+    IERC20TokenV06 erc20Token,
+    uint256 erc20FillAmount,
+    IERC1155Token erc1155Token,
+    uint256 erc1155TokenId,
+    uint128 erc1155FillAmount,
+    address matcher
+);
+
+/// @dev Emitted whenever an `ERC1155Order` is cancelled.
+/// @param orderHash The hash the order.
+/// @param maker The maker of the order.
+event ERC1155OrderCancelled(
+    bytes32 orderHash,
+    address maker
+);
+
+/// @dev Emitted when an `ERC1155Order` is pre-signed.
+///      Contains all the fields of the order.
+event ERC1155OrderPreSigned(
+    LibNFTOrder.TradeDirection direction,
+    address maker,
+    address taker,
+    uint256 expiry,
+    uint256 nonce,
+    IERC20TokenV06 erc20Token,
+    uint256 erc20TokenAmount,
+    LibNFTOrder.Fee[] fees,
+    IERC1155Token erc1155Token,
+    uint256 erc1155TokenId,
+    LibNFTOrder.Property[] erc1155TokenProperties,
+    uint128 erc1155TokenAmount
+);
+```
+
+## ERC1155 Orders
+
+### Basic Functionality
+
+```
+/// @dev Sells an ERC1155 asset to fill the given order.
+/// @param buyOrder The ERC1155 buy order.
+/// @param signature The order signature from the maker.
+/// @param erc1155TokenId The ID of the ERC1155 asset being
+///        sold. If the given order specifies properties,
+///        the asset must satisfy those properties. Otherwise,
+///        it must equal the tokenId in the order.
+/// @param erc1155SellAmount The amount of the ERC1155 asset
+///        to sell.
+/// @param unwrapNativeToken If this parameter is true and the
+///        ERC20 token of the order is e.g. WETH, unwraps the
+///        token before transferring it to the taker.
+/// @param callbackData If this parameter is non-zero, invokes
+///        `zeroExERC1155OrderCallback` on `msg.sender` after
+///        the ERC20 tokens have been transferred to `msg.sender`
+///        but before transferring the ERC1155 asset to the buyer.
+function sellERC1155(
+    LibNFTOrder.ERC1155Order _calldata_ buyOrder,
+    LibSignature.Signature _calldata_ signature,
+    uint256 erc1155TokenId,
+    uint128 erc1155SellAmount,
+    bool unwrapNativeToken,
+    bytes _calldata_ callbackData
+)
+    _external_;
+    
+/// @dev Buys an ERC1155 asset by filling the given order.
+/// @param sellOrder The ERC1155 sell order.
+/// @param signature The order signature.
+/// @param erc1155BuyAmount The amount of the ERC1155 asset
+///        to buy.
+/// @param callbackData If this parameter is non-zero, invokes
+///        `zeroExERC1155OrderCallback` on `msg.sender` after
+///        the ERC1155 asset has been transferred to `msg.sender`
+///        but before transferring the ERC20 tokens to the seller.
+///        Native tokens acquired during the callback can be used
+///        to fill the order.
+function buyERC1155(
+    LibNFTOrder.ERC1155Order _calldata_ sellOrder,
+    LibSignature.Signature _calldata_ signature,
+    uint128 erc1155BuyAmount,
+    bytes _calldata_ callbackData
+)
+    _external_
+    _payable_;
+    
+/// @dev Cancel a single ERC1155 order. The caller should be the
+///      maker of the order. Silently succeeds if the order has
+///      already been filled or cancelled.
+/// @param order The order to cancel.
+function cancelERC1155Order(LibNFTOrder.ERC1155Order _calldata_ order)
+    _external_;
+```
+
+### Advanced Functionality
+
+```
+/// @dev Cancel multiple ERC1155 orders. The caller should be the
+///      maker of the orders. Silently succeeds if an order has
+///      already been filled or cancelled.
+/// @param orders The orders to cancel.
+function batchCancelERC1155Orders(LibNFTOrder.ERC1155Order[] _calldata_ orders)
+    _external_;
+    
+/// @dev Buys multiple ERC1155 assets by filling the
+///      given orders.
+/// @param sellOrders The ERC1155 sell orders.
+/// @param signatures The order signatures.
+/// @param erc1155TokenAmounts The amounts of the ERC1155 assets
+///        to buy for each order.
+/// @param revertIfIncomplete If true, reverts if this
+///        function fails to fill any individual order.
+/// @return successes An array of booleans corresponding to whether
+///         each order in `orders` was successfully filled.
+function batchBuyERC1155s(
+    LibNFTOrder.ERC1155Order[] _calldata_ sellOrders,
+    LibSignature.Signature[] _calldata_ signatures,
+    uint128[] _calldata_ erc1155TokenAmounts,
+    bool revertIfIncomplete
+)
+    _external_
+    _payable_
+    returns (bool[] _memory_ successes);
+    
+/// @dev Callback for the ERC1155 `safeTransferFrom` function.
+///      This callback can be used to sell an ERC1155 asset if
+///      a valid ERC1155 order, signature and `unwrapNativeToken`
+///      are encoded in `data`. This allows takers to sell their
+///      ERC1155 asset without first calling `setApprovalForAll`.
+/// @param operator The address which called `safeTransferFrom`.
+/// @param from The address which previously owned the token.
+/// @param tokenId The ID of the asset being transferred.
+/// @param value The amount being transferred.
+/// @param data Additional data with no specified format. If a
+///        valid ERC1155 order, signature and `unwrapNativeToken`
+///        are encoded in `data`, this function will try to fill
+///        the order using the received asset.
+/// @return success The selector of this function (0xf23a6e61),
+///         indicating that the callback succeeded.
+function onERC1155Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    uint256 value,
+    bytes _calldata_ data
+)
+    _external_
+    returns (bytes4 success);
+    
+/// @dev Approves an ERC1155 order on-chain. After pre-signing
+///      the order, the `PRESIGNED` signature type will become
+///      valid for that order and signer.
+/// @param order An ERC1155 order.
+function preSignERC1155Order(LibNFTOrder.ERC1155Order _calldata_ order)
+    _external_;
+```
+
+### Read-only Functions
+
+```
+/// @dev Checks whether the given signature is valid for the
+///      the given ERC1155 order. Reverts if not.
+/// @param order The ERC1155 order.
+/// @param signature The signature to validate.
+function validateERC1155OrderSignature(
+    LibNFTOrder.ERC1155Order calldata order,
+    LibSignature.Signature calldata signature
+)
+    external
+    view;
+
+/// @dev If the given order is buying an ERC1155 asset, checks
+///      whether or not the given token ID satisfies the required
+///      properties specified in the order. If the order does not
+///      specify any properties, this function instead checks
+///      whether the given token ID matches the ID in the order.
+///      Reverts if any checks fail, or if the order is selling
+///      an ERC1155 asset.
+/// @param order The ERC1155 order.
+/// @param erc1155TokenId The ID of the ERC1155 asset.
+function validateERC1155OrderProperties(
+    LibNFTOrder.ERC1155Order calldata order,
+    uint256 erc1155TokenId
+)
+    external
+    view;
+
+/// @dev Get the order info for an ERC1155 order.
+/// @param order The ERC1155 order.
+/// @return orderInfo Infor about the order.
+function getERC1155OrderInfo(LibNFTOrder.ERC1155Order calldata order)
+    external
+    view
+    returns (LibNFTOrder.OrderInfo memory orderInfo);
+
+/// @dev Get the canonical hash of an ERC1155 order.
+/// @param order The ERC1155 order.
+/// @return orderHash The order hash.
+function getERC1155OrderHash(LibNFTOrder.ERC1155Order calldata order)
+    external
+    view
+    returns (bytes32 orderHash);
+```
+
+### Events
+
+```
+/// @dev Emitted whenever an `ERC721Order` is filled.
+/// @param direction Whether the order is selling or
+///        buying the ERC721 token.
+/// @param maker The maker of the order.
+/// @param taker The taker of the order.
+/// @param nonce The unique maker nonce in the order.
+/// @param erc20Token The address of the ERC20 token.
+/// @param erc20TokenAmount The amount of ERC20 token
+///        to sell or buy.
+/// @param erc721Token The address of the ERC721 token.
+/// @param erc721TokenId The ID of the ERC721 asset.
+/// @param matcher If this order was matched with another using `matchERC721Orders()`,
+///                this will be the address of the caller. If not, this will be `address(0)`.
+event ERC721OrderFilled(
+    LibNFTOrder.TradeDirection direction,
+    address maker,
+    address taker,
+    uint256 nonce,
+    IERC20TokenV06 erc20Token,
+    uint256 erc20TokenAmount,
+    IERC721Token erc721Token,
+    uint256 erc721TokenId,
+    address matcher
+);
+
+/// @dev Emitted whenever an `ERC721Order` is cancelled.
+/// @param maker The maker of the order.
+/// @param nonce The nonce of the order that was cancelled.
+event ERC721OrderCancelled(
+    address maker,
+    uint256 nonce
+);
+
+/// @dev Emitted when an `ERC721Order` is pre-signed.
+///      Contains all the fields of the order.
+event ERC721OrderPreSigned(
+    LibNFTOrder.TradeDirection direction,
+    address maker,
+    address taker,
+    uint256 expiry,
+    uint256 nonce,
+    IERC20TokenV06 erc20Token,
+    uint256 erc20TokenAmount,
+    LibNFTOrder.Fee[] fees,
+    IERC721Token erc721Token,
+    uint256 erc721TokenId,
+    LibNFTOrder.Property[] erc721TokenProperties
+);
+```
+

--- a/mdx/guides/0x-v4-nft-features-over.mdx
+++ b/mdx/guides/0x-v4-nft-features-over.mdx
@@ -1,8 +1,9 @@
 # 0x V4 NFT Features Overview
 
-> Note: his feature is in beta and is subject to change. Testnet deployments coming soon, mainnet deployments are pending audit.
+> Note: This feature is in beta and is subject to change. Testnet deployments coming soon. Mainnet deployments are pending audit.
+> We invite you to join our [Discord](https://discord.com/invite/YyG9fkK) and share feedback in the [#dev-feature-feedback](https://discord.com/channels/435912040142602260/936366257521954857).
 
-We are adding support for ERC721<>ERC20 and ERC1155<>ERC20 orders to 0x v4. Contracts can be found [here](https://github.com/0xProject/protocol/tree/refactor/nft-orders/contracts/zero-ex/contracts/src/features/nft_orders). Contract interfaces are also in this doc. 
+We are adding support for ERC721<>ERC20 and ERC1155<>ERC20 orders to 0x v4. Contracts can be found [here](https://github.com/0xProject/protocol/tree/refactor/nft-orders/contracts/zero-ex/contracts/src/features/nft_orders). Contract interfaces are also in [this doc](https://0x.org/docs/guides/0x-v4-nft-contract-interfaces)
 
 ## Basics
 
@@ -25,7 +26,7 @@ enum TradeDirection {
 }
 ```
 
-## Collection/floor/property-based orders
+## Collection/Floor/Property-Based Orders
 
 In lieu of specifying a particular token ID, buy orders can specify a list of properties that an NFT asset must satisfy to be used to fill the order.
 
@@ -127,7 +128,7 @@ For cheaper chains like Polygon, it may make sense for orders to specify multipl
 
 For expensive chains like Ethereum mainnet, disbursing multiple fees would be costly, so instead an order can specify a single `Fee`, the `recipient` of which is a contract that would handle splitting the fee between multiple recipients using a withdrawal model. 
 
-## ETH/WETH handling
+## ETH/WETH Handling
 
 A **sell** order must use WETH instead of ETH, since we require the ERC20 `transferFrom` functionality to transfer WETH from the maker to the taker. Even so, the taker can choose to *receive* ETH when filling a WETH sell order by setting the `unwrapNativeToken` parameter to `true` in `sellERC721` or `sellERC1155`.
 
@@ -139,7 +140,7 @@ A **buy** order can specify either ETH or WETH, i.e. the buyer can indicate whet
 
 This allows takers to fill an NFT buy order without needing to first approving the 0x contract. As a side-effect, this will also mitigate the risk of users accidentally sending NFTs to the 0x contract.
 
-## Order matching
+## Order Matching
 
 The `matchERC721Orders` function can be used to simultaneously fill a sell order and a buy order if:
 
@@ -148,7 +149,7 @@ The `matchERC721Orders` function can be used to simultaneously fill a sell order
 
 Order matching is currently only support for ERC721 orders. Support for ERC1155 order matching will be added at a future date if there is sufficient interest. 
 
-## Pre-signing orders
+## Pre-Signing Orders
 
 Since smart contracts cannot sign orders in the traditional sense, they can instead “sign” orders by calling the `preSignERC721Order` or `preSignERC1155Order` functions.
 

--- a/mdx/guides/0x-v4-nft-features-over.mdx
+++ b/mdx/guides/0x-v4-nft-features-over.mdx
@@ -1,0 +1,170 @@
+# 0x V4 NFT Features Overview
+
+> Note: his feature is in beta and is subject to change. Testnet deployments coming soon, mainnet deployments are pending audit.
+
+We are adding support for ERC721<>ERC20 and ERC1155<>ERC20 orders to 0x v4. Contracts can be found [here](https://github.com/0xProject/protocol/tree/refactor/nft-orders/contracts/zero-ex/contracts/src/features/nft_orders). Contract interfaces are also in this doc. 
+
+## Basics
+
+Users can sign an off-chain order to indicate that they are interested in:
+* **selling** a particular NFT for some amount of ERC20 token (or ETH), or
+* **buying** a particular NFT for some amount of ERC20 token.
+
+There are two Solidity order `structs`:
+* `ERC721Order` for buying/selling ERC721 assets
+* `ERC1155Order` for buying/selling ERC1155 assets.
+
+`ERC1155Order` has one additional field compared to `ERC721Order`, used to specify the amount of the ERC1155 being bought or sold. This would be used for fungible ERC1155 assets. 
+
+The `TradeDirection` enum is used to indicate whether an order is a bid or an ask:
+
+```
+enum TradeDirection {
+    SELL_NFT,
+    BUY_NFT
+}
+```
+
+## Collection/floor/property-based orders
+
+In lieu of specifying a particular token ID, buy orders can specify a list of properties that an NFT asset must satisfy to be used to fill the order.
+
+These properties are encoded using the following struct:
+
+```
+struct Property {
+    IPropertyValidator propertyValidator;
+    bytes propertyData;
+}
+```
+
+where `propertyValidator` implements the following function:
+
+```
+/// @dev Checks that the given ERC721/ERC1155 asset satisfies the properties encoded in `propertyData`.
+///      Should revert if the asset does not satisfy the specified properties.
+/// @param tokenAddress The ERC721/ERC1155 token contract address.
+/// @param tokenId The ERC721/ERC1155 tokenId of the asset to check.
+/// @param propertyData Encoded properties or auxiliary data needed to perform the check.
+function validateProperty(
+    address tokenAddress,
+    uint256 tokenId,
+    bytes calldata propertyData
+)
+    external
+    view;
+```
+
+A property validator contract could check that the provided tokenId has a particular attribute, which would be encoded in `propertyData`.
+
+Properties are validated as follows:
+
+```
+// Validate each property
+for (uint256 i = 0; i < order.nftProperties.length; i++) {
+    LibNFTOrder.Property memory property = order.nftProperties[i];
+    // `address(0)` is interpreted as a no-op. Any token ID
+    // will satisfy a property with `propertyValidator == address(0)`.
+    if (address(property.propertyValidator) == address(0)) {
+        continue;
+    }
+
+    // Call the property validator and throw a descriptive error
+    // if the call reverts.
+    try property.propertyValidator.validateProperty(
+        order.nft,
+        tokenId,
+        property.propertyData
+    ) {} catch (bytes memory errorData) {
+        LibNFTOrdersRichErrors.PropertyValidationFailedError(
+            address(property.propertyValidator),
+            order.nft,
+            tokenId,
+            property.propertyData,
+            errorData
+        ).rrevert();
+    }
+}
+```
+
+By using a single `Property` with `propertyValidator == address(0)`, one can create "collection" or "floor" orders –– these orders can be filled using any NFT from a particular collection.  
+
+## Fees
+
+An order can specify fees to be paid out during settlement, denominated in the ERC20 token of the order. Both `ERC721Order` and `ERC1155Order` have a `Fee[] fees` field, where `Fee` is the following `struct`:
+
+```
+struct Fee {
+    address recipient;
+    uint256 amount;
+    bytes feeData;
+}
+```
+
+For each `Fee` specified in an order, the **buyer** of the NFT will pay the fee recipient the given amount of ETH/ERC20 tokens. This is in *addition* to the `erc20TokenAmount` that the buyer is paying for the NFT itself. There is an optional callback for each fee:
+
+```
+// Note that the fee callback is _not_ called if zero
+// `feeData` is provided. If `feeData` is provided, we assume
+// the fee recipient is a contract that implements the
+// `IFeeRecipient` interface.
+if (fee.feeData.length > 0) {
+    // Invoke the callback
+    bytes4 callbackResult = IFeeRecipient(fee.recipient).receiveZeroExFeeCallback(
+        useNativeToken ? NATIVE_TOKEN_ADDRESS : address(order.erc20Token),
+        feeFillAmount,
+        fee.feeData
+    );
+    // Check for the magic success bytes
+    require(
+        callbackResult == FEE_CALLBACK_MAGIC_BYTES,
+        "NFTOrders::_payFees/CALLBACK_FAILED"
+    );
+}
+```
+
+For cheaper chains like Polygon, it may make sense for orders to specify multiple `Fees` so that the fees can be disbursed during order settlement.
+
+For expensive chains like Ethereum mainnet, disbursing multiple fees would be costly, so instead an order can specify a single `Fee`, the `recipient` of which is a contract that would handle splitting the fee between multiple recipients using a withdrawal model. 
+
+## ETH/WETH handling
+
+A **sell** order must use WETH instead of ETH, since we require the ERC20 `transferFrom` functionality to transfer WETH from the maker to the taker. Even so, the taker can choose to *receive* ETH when filling a WETH sell order by setting the `unwrapNativeToken` parameter to `true` in `sellERC721` or `sellERC1155`.
+
+A **buy** order can specify either ETH or WETH, i.e. the buyer can indicate whether they would like to receive ETH or WETH. A ** WETH sell order can be filled by a taker using ETH: the `buyERC721` and `buyERC1155` functions are `payable` and the `msg.value` can be used to fill a WETH sell order.
+
+## `onERC721Received` and `onERC1155Received`
+
+0x V4 will implement the ERC721 and ERC1155 callback functions. If an order and signature are encoded in the `data` parameter of a `safeTransferFrom` call, the 0x contract will try to fill the given order using the NFT asset transferred to it. 
+
+This allows takers to fill an NFT buy order without needing to first approving the 0x contract. As a side-effect, this will also mitigate the risk of users accidentally sending NFTs to the 0x contract.
+
+## Order matching
+
+The `matchERC721Orders` function can be used to simultaneously fill a sell order and a buy order if:
+
+* They are buying/selling the same ERC721 asset, or the sell order is selling an asset that satisfies the properties specified by the buy order
+* There is a profitable spread (*after* fees), i.e. the following quantity is non-negative: `profit = buyOrder.erc20TokenAmount - sellOrder.erc20TokenAmount - sellOrderFees`
+
+Order matching is currently only support for ERC721 orders. Support for ERC1155 order matching will be added at a future date if there is sufficient interest. 
+
+## Pre-signing orders
+
+Since smart contracts cannot sign orders in the traditional sense, they can instead “sign” orders by calling the `preSignERC721Order` or `preSignERC1155Order` functions.
+
+If an order has been pre-signed, it can by providing a “null” signature with the `PRESIGNED` signature type (see [LibSignature.sol](https://github.com/0xProject/protocol/blob/refactor/nft-orders/contracts/zero-ex/contracts/src/features/libs/LibSignature.sol#L42-L61)):
+
+```
+LibSignature.Signature({
+   signatureType: LibSignature.SignatureType.PRESIGNED,
+   v: uint8(0),
+   r: bytes32(0),
+   s: bytes32(0)
+});
+```
+
+A smart contract can subsequently cancel an order just like an EOA would, by calling the `cancelERC721Order` or `cancelERC1155Order` functions.
+
+The pre-sign functions will emit the entire order as an event, so that the order is easily indexable by subgraphs and thus easily discoverable without the need for an off-chain database. 
+
+Note that EOAs can also call the pre-sign functions if they so desire.


### PR DESCRIPTION
Add two new v4 NFT docs - an overview of the multi-chain NFT swaps powered by 0x v4 and the contract interfaces. 