### PR TITLE
Add full support for Vercel and add redirects for now deprecated docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     },
     "resolutions": {
         "node-hid": "2.1.1",
-        "scrypt": "github:barrysteyn/node-scrypt#fb60a8d"
+        "scrypt": "github:barrysteyn/node-scrypt#fb60a8d",
+        "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
     },
     "author": "Fabio Berger",
     "license": "Apache-2.0",

--- a/ts/components/dropdowns/dropdown_docs.tsx
+++ b/ts/components/dropdowns/dropdown_docs.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { Heading, Paragraph } from 'ts/components/text';
-import { WebsitePaths } from 'ts/types';
 
 import { Link } from '../documentation/shared/link';
 
@@ -9,11 +8,6 @@ const navData = [
     {
         title: '0x Docs',
         description: 'Learn and build with 0x',
-        url: WebsitePaths.Docs,
-    },
-    {
-        title: '(Alpha Release) 0x Docs',
-        description: 'Get a sneak peek at our updated documentation',
         url: 'https://docs.0x.org/',
         shouldOpenInNewTab: true,
     },

--- a/ts/components/dropdowns/dropdown_docs.tsx
+++ b/ts/components/dropdowns/dropdown_docs.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { Heading, Paragraph } from 'ts/components/text';
 import { WebsitePaths } from 'ts/types';
-import { constants } from 'ts/utils/constants';
 
 import { Link } from '../documentation/shared/link';
 

--- a/ts/components/header.tsx
+++ b/ts/components/header.tsx
@@ -7,7 +7,7 @@ import { Link } from 'ts/components/documentation/shared/link';
 import { Button } from 'ts/components/button';
 // import { DropdownProducts } from 'ts/components/dropdowns/dropdown_products';
 // import { DropdownResources } from 'ts/components/dropdowns/dropdown_resources';
-import { DropdownDocs } from 'ts/components/dropdowns/dropdown_docs';
+// import { DropdownDocs } from 'ts/components/dropdowns/dropdown_docs';
 import { Hamburger } from 'ts/components/hamburger';
 import { Logo } from 'ts/components/logo';
 import { MobileNav } from 'ts/components/mobile_nav';
@@ -41,9 +41,8 @@ interface DropdownWrapInterface {
 const navItems: NavItemProps[] = [
     {
         id: 'docs',
-        text: 'Developers',
-        dropdownComponent: DropdownDocs,
-        dropdownWidth: 270,
+        text: 'Documentation',
+        url: 'https://docs.0x.org/',
     },
     {
         id: 'zrx',

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,6 @@
             "destination": "https://docs.0x.org/",
             "permanent": true
         },
-        { "source": "/(.*)", "destination": "/" }
+        { "source": "/(.+)", "destination": "/" }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,16 @@
             "permanent": true
         },
         {
+            "source": "/docs/tools",
+            "destination": "https://docs.0x.org/",
+            "permanent": true
+        },
+        {
+            "source": "/docs/guides",
+            "destination": "https://docs.0x.org/introduction/guides",
+            "permanent": true
+        },
+        {
             "source": "/docs/:path*",
             "destination": "https://docs.0x.org/:path*",
             "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,6 @@
             "destination": "https://docs.0x.org/",
             "permanent": true
         },
-        { "src": "/[^.]+", "dest": "/", "status": 200 }
+        { "source": "/[^.]+", "destination": "/", "statusCode": 200 }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -29,7 +29,7 @@
             "source": "/docs",
             "destination": "https://docs.0x.org/",
             "permanent": true
-        },
-        { "source": "/(.+)", "destination": "/" }
-    ]
+        }
+    ],
+    "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,6 @@
             "destination": "https://docs.0x.org/",
             "permanent": true
         },
-        { "source": "/:path+", "destination": "/", "statusCode": 200 }
+        { "source": "/(.*)", "destination": "/" }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,7 @@
             "source": "/docs",
             "destination": "https://docs.0x.org/",
             "permanent": true
-        }
+        },
+        { "src": "/[^.]+", "dest": "/", "status": 200 }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,11 @@
             "source": "/docs/:path*",
             "destination": "https://docs.0x.org/:path*",
             "permanent": true
+        },
+        {
+            "source": "/docs",
+            "destination": "https://docs.0x.org/",
+            "permanent": true
         }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,6 @@
             "destination": "https://docs.0x.org/",
             "permanent": true
         },
-        { "source": "/[^.]+", "destination": "/", "statusCode": 200 }
+        { "source": "/:path+", "destination": "/", "statusCode": 200 }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -31,5 +31,5 @@
             "permanent": true
         }
     ],
-    "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }]
+    "rewrites": [{ "source": "/:path+", "destination": "/" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+    "redirects": [
+        {
+            "source": "/docs/api",
+            "destination": "https://docs.0x.org/0x-api-swap/api-references",
+            "permanent": true
+        },
+        {
+            "source": "/docs/core-concepts",
+            "destination": "https://docs.0x.org/introduction/introduction-to-0x",
+            "permanent": true
+        },
+        {
+            "source": "/docs/:path*",
+            "destination": "https://docs.0x.org/:path*",
+            "permanent": true
+        }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5227,13 +5227,6 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-bufferutil@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.3.tgz#66724b756bed23cd7c28c4d306d7994f9943cc6b"
-  integrity sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==
-  dependencies:
-    node-gyp-build "^4.2.0"
-
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -6652,14 +6645,6 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -7401,15 +7386,6 @@ es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-symbol "~3.1.1"
     next-tick "1"
 
-es5-ext@^0.10.50:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
-
 es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
@@ -7432,14 +7408,6 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -8560,13 +8528,6 @@ express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-ext@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
-  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
-  dependencies:
-    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -12775,10 +12736,6 @@ nan@2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
-nan@^2.11.0:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-
 nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.2.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -12863,7 +12820,7 @@ new-array@^1.0.0:
   resolved "https://registry.yarnpkg.com/new-array/-/new-array-1.0.0.tgz#5dbc639d961eac7f1a9fbc1a7146ec12f2924fbf"
   integrity sha1-XbxjnZYerH8an7wacUbsEvKST78=
 
-next-tick@1, next-tick@~1.0.0:
+next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
@@ -17707,21 +17664,11 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.3.0.tgz#ada7c045f07ead08abf9e2edd29be1a0c0661132"
-  integrity sha512-rgPIqOdfK/4J9FhiVrZ3cveAjRRo5rsQBAIhnylX874y1DX/kEKSVdLsnuHB6l1KTjHyU01VjiMBHgU2adejyg==
-
 typed-styles@^0.0.5:
   version "0.0.5"
   resolved "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.5.tgz#a60df245d482a9b1adf9c06c078d0f06085ed1cf"
 
-typedarray-to-buffer@3.1.5, typedarray-to-buffer@^3.1.2, typedarray-to-buffer@^3.1.5:
+typedarray-to-buffer@3.1.5, typedarray-to-buffer@^3.1.2:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   dependencies:
@@ -18135,13 +18082,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
     kind-of "^6.0.2"
-
-utf-8-validate@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.4.tgz#72a1735983ddf7a05a43a9c6b67c5ce1c910f9b8"
-  integrity sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==
-  dependencies:
-    node-gyp-build "^4.2.0"
 
 utf8@2.1.1:
   version "2.1.1"
@@ -19099,51 +19039,9 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
-websocket@1.0.26:
+websocket@1.0.26, websocket@1.0.32, websocket@^1.0.26, websocket@^1.0.31, "websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible", "websocket@github:frozeman/WebSocket-Node#browserifyCompatible":
   version "1.0.26"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.26.tgz#a03a01299849c35268c83044aa919c6374be8194"
-  dependencies:
-    debug "^2.2.0"
-    nan "^2.3.3"
-    typedarray-to-buffer "^3.1.2"
-    yaeti "^0.0.6"
-
-websocket@1.0.32:
-  version "1.0.32"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
-  integrity sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==
-  dependencies:
-    bufferutil "^4.0.1"
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    typedarray-to-buffer "^3.1.5"
-    utf-8-validate "^5.0.2"
-    yaeti "^0.0.6"
-
-websocket@^1.0.26:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.28.tgz#9e5f6fdc8a3fe01d4422647ef93abdd8d45a78d3"
-  dependencies:
-    debug "^2.2.0"
-    nan "^2.11.0"
-    typedarray-to-buffer "^3.1.5"
-    yaeti "^0.0.6"
-
-websocket@^1.0.31:
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
-  integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
-  dependencies:
-    bufferutil "^4.0.1"
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    typedarray-to-buffer "^3.1.5"
-    utf-8-validate "^5.0.2"
-    yaeti "^0.0.6"
-
-"websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible":
-  version "1.0.26"
-  resolved "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+  resolved "https://codeload.github.com/frozeman/WebSocket-Node/tar.gz/6c72925e3f8aaaea8dc8450f97627e85263999f2"
   dependencies:
     debug "^2.2.0"
     nan "^2.3.3"


### PR DESCRIPTION
This PR adds and configures support for Vercel using the added `vercel.json` file.
Additionally, references to the old documentation were removed (as it is now deprecated) and common link to old
docs automatically redirect to their counterparts in the new docs using vercel redirects. 

A "live-like" preview can be seen here: https://verceltest.0x.org/