### PR TITLE
Add forum integration to governance page

### DIFF
--- a/ts/components/governance/treasury_summary.tsx
+++ b/ts/components/governance/treasury_summary.tsx
@@ -32,4 +32,5 @@ const TruncatedParagraph = styled(Paragraph)`
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+    -webkit-box-align: start !important;
 `;

--- a/ts/components/governance/treasury_summary.tsx
+++ b/ts/components/governance/treasury_summary.tsx
@@ -1,5 +1,6 @@
 import marked, { Token, Tokens } from 'marked';
 import React from 'react';
+import styled from 'styled-components';
 
 import { Heading, Paragraph } from 'ts/components/text';
 
@@ -18,7 +19,17 @@ export const TreasurySummary: React.FC<{ description: string }> = ({ description
     return (
         <>
             <Heading marginBottom="15px">{(heading as Tokens.Heading).text}</Heading>
-            <Paragraph marginBottom="20px">{summary}</Paragraph>
+            <TruncatedParagraph marginBottom="20px">{summary}</TruncatedParagraph>
         </>
     );
 };
+
+const TruncatedParagraph = styled(Paragraph)`
+    line-height: 1.4rem !important;
+    max-height: calc(1.4rem * n3);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+`;

--- a/ts/components/newLayout.tsx
+++ b/ts/components/newLayout.tsx
@@ -117,7 +117,7 @@ export const WrapSticky = styled.div<WrapProps>`
 const SectionBase = styled.section<SectionProps>`
     width: ${(props) => !props.isFullWidth && 'calc(100% - 60px)'};
     min-height: ${(props) => props.minHeight || 'auto'};
-    max-width: 1500px;
+    max-width: ${(props) => props.maxWidth || '1500px'};
     cursor: ${(props) => props.hasHover && 'pointer'};
     border: ${(props) => props.hasBorder && `1px solid ${props.theme.lightBgColor}`};
     margin: ${(props) => (props.margin ? props.margin : '0 auto')};
@@ -138,7 +138,7 @@ const SectionBase = styled.section<SectionProps>`
 
 const Wrap = styled(FlexWrap)<WrapProps>`
     width: ${(props) => props.wrapWidth || 'calc(100% - 60px)'};
-    width: ${(props) => props.bgColor && 'calc(100% - 60px)'};
+    background-color: ${(props) => props.theme[`${props.bgColor}BgColor`] || props.bgColor};
     max-width: ${(props) => !props.isFullWidth && (props.maxWidth || '895px')};
     text-align: ${(props) => props.isTextCentered && 'center'};
     margin: 0 auto;

--- a/ts/hooks/use_async.ts
+++ b/ts/hooks/use_async.ts
@@ -9,7 +9,7 @@ export const useAsync = <T, E = string>(asyncFunction: () => Promise<T>, immedia
     // handles setting state for pending, value, and error.
     // useCallback ensures the below useEffect is not called
     // on every render, but only if asyncFunction changes.
-    const execute = useCallback(() => {
+    const execute = useCallback(async () => {
         setStatus('pending');
         setValue(null);
         setError(null);
@@ -18,8 +18,8 @@ export const useAsync = <T, E = string>(asyncFunction: () => Promise<T>, immedia
                 setValue(response);
                 setStatus('success');
             })
-            .catch((error: any) => {
-                setError(error);
+            .catch((e: any) => {
+                setError(e);
                 setStatus('error');
             });
     }, [asyncFunction]);
@@ -28,6 +28,7 @@ export const useAsync = <T, E = string>(asyncFunction: () => Promise<T>, immedia
     // in an onClick handler.
     useEffect(() => {
         if (immediate) {
+            // tslint:disable-next-line:no-floating-promises
             execute();
         }
     }, [execute, immediate]);

--- a/ts/hooks/use_async.ts
+++ b/ts/hooks/use_async.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// https://usehooks.com/useAsync/
+export const useAsync = <T, E = string>(asyncFunction: () => Promise<T>, immediate = true) => {
+    const [status, setStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle');
+    const [value, setValue] = useState<T | null>(null);
+    const [error, setError] = useState<E | null>(null);
+    // The execute function wraps asyncFunction and
+    // handles setting state for pending, value, and error.
+    // useCallback ensures the below useEffect is not called
+    // on every render, but only if asyncFunction changes.
+    const execute = useCallback(() => {
+        setStatus('pending');
+        setValue(null);
+        setError(null);
+        return asyncFunction()
+            .then((response: any) => {
+                setValue(response);
+                setStatus('success');
+            })
+            .catch((error: any) => {
+                setError(error);
+                setStatus('error');
+            });
+    }, [asyncFunction]);
+    // Call execute if we want to fire it right away.
+    // Otherwise execute can be called later, such as
+    // in an onClick handler.
+    useEffect(() => {
+        if (immediate) {
+            execute();
+        }
+    }, [execute, immediate]);
+    return { execute, status, value, error };
+};

--- a/ts/pages/governance/forum_thread_card.tsx
+++ b/ts/pages/governance/forum_thread_card.tsx
@@ -43,8 +43,8 @@ const MetaParagraph = styled(Paragraph)`
 
 const ForumThreadHeading = styled(Heading)`
     margin-bottom: 8px !important;
-    line-height: 1rem !important;
-    max-height: 1rem;
+    line-height: 1.1rem !important;
+    max-height: 1.1rem;
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;

--- a/ts/pages/governance/forum_thread_card.tsx
+++ b/ts/pages/governance/forum_thread_card.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Section } from 'ts/components/newLayout';
+import { Heading, Paragraph } from 'ts/components/text';
+import ReactTooltip from 'react-tooltip';
+import { Link as ReactRouterLink } from 'react-router-dom';
+import styled from 'styled-components';
+import { colors } from 'ts/style/colors';
+
+interface ForumThreadCardProps {
+    title: string;
+    author: string;
+    numComments: number;
+    url: string;
+}
+
+export default function ForumThreadCard({ title, author, numComments, url }: ForumThreadCardProps): JSX.Element {
+    return (
+        <ReactRouterLink to={{ pathname: url }} target="_blank">
+            <Section hasBorder bgColor="none" padding="24px 35px" hasHover margin="0" isFullWidth wrapWidth="100%">
+                <ForumThreadHeading size="small" data-tip={title}>
+                    {title}
+                </ForumThreadHeading>
+                <ReactTooltip />
+                <MetaParagraph
+                    fontSize="17px"
+                    color={colors.textDarkSecondary}
+                >{`By ${author}  \u25CF  ${numComments} comments`}</MetaParagraph>
+            </Section>
+        </ReactRouterLink>
+    );
+}
+
+const MetaParagraph = styled(Paragraph)`
+    margin: 0 !important;
+`;
+
+const ForumThreadHeading = styled(Heading)`
+    margin-bottom: 8px !important;
+    line-height: 1rem !important;
+    max-height: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+`;

--- a/ts/pages/governance/forum_thread_card.tsx
+++ b/ts/pages/governance/forum_thread_card.tsx
@@ -21,7 +21,7 @@ export function ForumThreadCard({ title, author, numComments, url }: ForumThread
                 bgColor="none"
                 padding="24px 35px"
                 hasHover={true}
-                margin="0"
+                margin="0 0 35px 0"
                 isFullWidth={true}
                 wrapWidth="100%"
             >

--- a/ts/pages/governance/forum_thread_card.tsx
+++ b/ts/pages/governance/forum_thread_card.tsx
@@ -43,4 +43,5 @@ const ForumThreadHeading = styled(Heading)`
     display: -webkit-box;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
+    -webkit-box-align: start !important;
 `;

--- a/ts/pages/governance/forum_thread_card.tsx
+++ b/ts/pages/governance/forum_thread_card.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { Link as ReactRouterLink } from 'react-router-dom';
+import ReactTooltip from 'react-tooltip';
+import styled from 'styled-components';
 import { Section } from 'ts/components/newLayout';
 import { Heading, Paragraph } from 'ts/components/text';
-import ReactTooltip from 'react-tooltip';
-import { Link as ReactRouterLink } from 'react-router-dom';
-import styled from 'styled-components';
 import { colors } from 'ts/style/colors';
 
 interface ForumThreadCardProps {
@@ -13,18 +13,25 @@ interface ForumThreadCardProps {
     url: string;
 }
 
-export default function ForumThreadCard({ title, author, numComments, url }: ForumThreadCardProps): JSX.Element {
+export function ForumThreadCard({ title, author, numComments, url }: ForumThreadCardProps): JSX.Element {
     return (
         <ReactRouterLink to={{ pathname: url }} target="_blank">
-            <Section hasBorder bgColor="none" padding="24px 35px" hasHover margin="0" isFullWidth wrapWidth="100%">
+            <Section
+                hasBorder={true}
+                bgColor="none"
+                padding="24px 35px"
+                hasHover={true}
+                margin="0"
+                isFullWidth={true}
+                wrapWidth="100%"
+            >
                 <ForumThreadHeading size="small" data-tip={title}>
                     {title}
                 </ForumThreadHeading>
                 <ReactTooltip />
-                <MetaParagraph
-                    fontSize="17px"
-                    color={colors.textDarkSecondary}
-                >{`By ${author}  \u25CF  ${numComments} comments`}</MetaParagraph>
+                <MetaParagraph fontSize="17px" color={colors.textDarkSecondary}>
+                    {`By ${author}  \u25CF  ${numComments} comments`}
+                </MetaParagraph>
             </Section>
         </ReactRouterLink>
     );

--- a/ts/pages/governance/vote_index.tsx
+++ b/ts/pages/governance/vote_index.tsx
@@ -1,5 +1,6 @@
 import { ZrxTreasuryContract } from '@0x/contracts-treasury';
 import { BigNumber } from '@0x/utils';
+import { Web3Wrapper } from '@0x/web3-wrapper';
 import { gql, request } from 'graphql-request';
 import * as _ from 'lodash';
 import CircularProgress from 'material-ui/CircularProgress';
@@ -7,31 +8,28 @@ import moment from 'moment';
 import * as React from 'react';
 import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
+import { useAsync } from 'react-use';
 import styled from 'styled-components';
-import { fadeIn } from 'ts/style/keyframes';
-
-import { Web3Wrapper } from '@0x/web3-wrapper';
-
-import { backendClient } from 'ts/utils/backend_client';
-
 import { Button } from 'ts/components/button';
 import { DocumentTitle } from 'ts/components/document_title';
 import { GovernanceHero } from 'ts/components/governance/hero';
 import { RegisterBanner } from 'ts/components/governance/register_banner';
 import { StakingPageLayout } from 'ts/components/staking/layout/staking_page_layout';
+import { Heading } from 'ts/components/text';
 import { Text } from 'ts/components/ui/text';
 import { Proposal, proposals as prodProposals, stagingProposals, TreasuryProposal } from 'ts/pages/governance/data';
 import { VoteIndexCard } from 'ts/pages/governance/vote_index_card';
 import { State } from 'ts/redux/reducer';
 import { colors } from 'ts/style/colors';
+import { fadeIn } from 'ts/style/keyframes';
 import { OnChainProposal, TallyInterface, VotingCardType } from 'ts/types';
+import { backendClient } from 'ts/utils/backend_client';
 import { configs, GOVERNANCE_THEGRAPH_ENDPOINT, GOVERNOR_CONTRACT_ADDRESS } from 'ts/utils/configs';
 import { documentConstants } from 'ts/utils/document_meta_constants';
 import { environments } from 'ts/utils/environments';
-import { Heading } from 'ts/components/text';
-import ForumThreadCard from './forum_thread_card';
-import { getTopNPosts } from 'ts/utils/forum_client';
-import { useAsync } from 'react-use';
+import { getTopNPostsAsync } from 'ts/utils/forum_client';
+
+import { ForumThreadCard } from './forum_thread_card';
 
 const FETCH_PROPOSALS = gql`
     query proposals {
@@ -232,7 +230,7 @@ export const VoteIndex: React.FC<VoteIndexProps> = () => {
         })();
     }, []);
 
-    const { loading: postsLoading, error: postsError, value: posts } = useAsync(getTopNPosts, []);
+    const { loading: isPostsLoading, value: posts } = useAsync(getTopNPostsAsync, []);
 
     const { data, isLoading } = useQuery('proposals', async () => {
         const { proposals: treasuryProposals } = await request(GOVERNANCE_THEGRAPH_ENDPOINT, FETCH_PROPOSALS);
@@ -473,7 +471,7 @@ export const VoteIndex: React.FC<VoteIndexProps> = () => {
                     </Button>
                 </FlexRow>
                 <TopPostsRow>
-                    {postsLoading ? (
+                    {isPostsLoading ? (
                         <LoaderWrapper>
                             <CircularProgress size={40} thickness={2} color={colors.brandLight} />
                         </LoaderWrapper>

--- a/ts/pages/governance/vote_index.tsx
+++ b/ts/pages/governance/vote_index.tsx
@@ -27,7 +27,7 @@ import { backendClient } from 'ts/utils/backend_client';
 import { configs, GOVERNANCE_THEGRAPH_ENDPOINT, GOVERNOR_CONTRACT_ADDRESS } from 'ts/utils/configs';
 import { documentConstants } from 'ts/utils/document_meta_constants';
 import { environments } from 'ts/utils/environments';
-import { getTopNPostsAsync } from 'ts/utils/forum_client';
+import { ForumTopic, getLatestNPostsFilteredAsync, getTopNPostsAsync } from 'ts/utils/forum_client';
 
 import { ForumThreadCard } from './forum_thread_card';
 
@@ -230,7 +230,12 @@ export const VoteIndex: React.FC<VoteIndexProps> = () => {
         })();
     }, []);
 
-    const { loading: isPostsLoading, value: posts } = useAsync(getTopNPostsAsync, []);
+    const retrievalFunc = async () => {
+        const filterFunc = (topic: ForumTopic) => topic.numPosts > 1;
+        return getLatestNPostsFilteredAsync(3, filterFunc);
+    };
+
+    const { loading: isPostsLoading, value: posts } = useAsync(retrievalFunc, []);
 
     const { data, isLoading } = useQuery('proposals', async () => {
         const { proposals: treasuryProposals } = await request(GOVERNANCE_THEGRAPH_ENDPOINT, FETCH_PROPOSALS);

--- a/ts/pages/governance/vote_index.tsx
+++ b/ts/pages/governance/vote_index.tsx
@@ -462,7 +462,7 @@ export const VoteIndex: React.FC<VoteIndexProps> = () => {
                     </SubmitButton>
                 </StyledForm>
             </NewVoteNotificationSignup>
-            <Wrapper>
+            <Wrapper style={{ marginTop: '60px' }}>
                 <FlexRow>
                     <FlexRowHeading>Top Forum Discussions:</FlexRowHeading>
                     <Button
@@ -769,6 +769,9 @@ const TopPostsRow = styled.div`
     padding-right: 1.65rem;
     padding-left: 1.65rem;
     margin-bottom: 60px;
+    @media (max-width: 768px) {
+        grid-template-columns: 1fr;
+    }
 `;
 
 const FlexRow = styled.div`

--- a/ts/pages/governance/vote_index.tsx
+++ b/ts/pages/governance/vote_index.tsx
@@ -27,7 +27,7 @@ import { backendClient } from 'ts/utils/backend_client';
 import { configs, GOVERNANCE_THEGRAPH_ENDPOINT, GOVERNOR_CONTRACT_ADDRESS } from 'ts/utils/configs';
 import { documentConstants } from 'ts/utils/document_meta_constants';
 import { environments } from 'ts/utils/environments';
-import { ForumTopic, getLatestNPostsFilteredAsync, getTopNPostsAsync } from 'ts/utils/forum_client';
+import { ForumTopic, getLatestNPostsFilteredAsync } from 'ts/utils/forum_client';
 
 import { ForumThreadCard } from './forum_thread_card';
 

--- a/ts/pages/governance/vote_index.tsx
+++ b/ts/pages/governance/vote_index.tsx
@@ -28,6 +28,10 @@ import { OnChainProposal, TallyInterface, VotingCardType } from 'ts/types';
 import { configs, GOVERNANCE_THEGRAPH_ENDPOINT, GOVERNOR_CONTRACT_ADDRESS } from 'ts/utils/configs';
 import { documentConstants } from 'ts/utils/document_meta_constants';
 import { environments } from 'ts/utils/environments';
+import { Heading } from 'ts/components/text';
+import ForumThreadCard from './forum_thread_card';
+import { getTopNPosts } from 'ts/utils/forum_client';
+import { useAsync } from 'react-use';
 
 const FETCH_PROPOSALS = gql`
     query proposals {
@@ -227,6 +231,8 @@ export const VoteIndex: React.FC<VoteIndexProps> = () => {
             setSnapshotProposals(proposalsAndVotes);
         })();
     }, []);
+
+    const { loading: postsLoading, error: postsError, value: posts } = useAsync(getTopNPosts, []);
 
     const { data, isLoading } = useQuery('proposals', async () => {
         const { proposals: treasuryProposals } = await request(GOVERNANCE_THEGRAPH_ENDPOINT, FETCH_PROPOSALS);
@@ -453,6 +459,38 @@ export const VoteIndex: React.FC<VoteIndexProps> = () => {
                     </SubmitButton>
                 </StyledForm>
             </NewVoteNotificationSignup>
+            <Wrapper>
+                <FlexRow>
+                    <FlexRowHeading>Top Forum Discussions:</FlexRowHeading>
+                    <Button
+                        isWithArrow={true}
+                        isAccentColor={true}
+                        fontSize="20px"
+                        href="https://gov.0x.org/"
+                        target="_blank"
+                    >
+                        Visit Forum
+                    </Button>
+                </FlexRow>
+                <TopPostsRow>
+                    {postsLoading ? (
+                        <LoaderWrapper>
+                            <CircularProgress size={40} thickness={2} color={colors.brandLight} />
+                        </LoaderWrapper>
+                    ) : (
+                        posts &&
+                        posts.map((post) => (
+                            <ForumThreadCard
+                                author={post.author.username}
+                                numComments={post.numPosts}
+                                title={post.title}
+                                url={post.url}
+                                key={post.id}
+                            />
+                        ))
+                    )}
+                </TopPostsRow>
+            </Wrapper>
             {/* <Column>
                     <Heading size="medium" isCentered={true}>
                         Govern 0x Protocol
@@ -719,5 +757,34 @@ const SignupCTA = styled.div`
         max-width: 100%;
         margin-bottom: 1rem;
     }
+`;
+
+const TopPostsRow = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    column-gap: 20px;
+    padding-right: 1.65rem;
+    padding-left: 1.65rem;
+    margin-bottom: 60px;
+`;
+
+const FlexRow = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    position: relative;
+    padding-right: 1.65rem;
+    padding-left: 1.65rem;
+    margin-bottom: 30px;
+
+    * + * {
+        margin-left: 8px;
+    }
+`;
+
+const FlexRowHeading = styled(Heading)`
+    flex-grow: 1;
+    margin: 0;
+    margin-bottom: 0 !important;
 `;
 // tslint:disable:max-file-line-count

--- a/ts/pages/governance/vote_index_card.tsx
+++ b/ts/pages/governance/vote_index_card.tsx
@@ -222,7 +222,7 @@ export const VoteIndexCard: React.StatelessComponent<VoteIndexCardProps> = (prop
                                     <Muted>{`(ZEIP-${zeipId})`}</Muted>
                                 </Heading>
 
-                                <Paragraph marginBottom="20px">{summary[0]}</Paragraph>
+                                <TruncatedParagraph marginBottom="20px">{summary[0]}</TruncatedParagraph>
                             </Column>
                             <Column width="25%" className="flex flex-column justify-center">
                                 <div className="flex flex-column sm-col-12">
@@ -267,7 +267,7 @@ export const VoteIndexCard: React.StatelessComponent<VoteIndexCardProps> = (prop
                                 <Heading marginBottom="15px">{`${props.title} `}</Heading>
                                 {props.body ? (
                                     <>
-                                        <Paragraph marginBottom="12px">{snapshotText}</Paragraph>
+                                        <TruncatedParagraph marginBottom="12px">{snapshotText}</TruncatedParagraph>
                                     </>
                                 ) : (
                                     <VoteCardShimmer>
@@ -403,4 +403,14 @@ const VoteCardShimmer = styled.div`
             width: 100%;
         }
     }
+`;
+
+const TruncatedParagraph = styled(Paragraph)`
+    line-height: 1.4rem !important;
+    max-height: calc(1.4rem * n3);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 `;

--- a/ts/pages/governance/vote_index_card.tsx
+++ b/ts/pages/governance/vote_index_card.tsx
@@ -413,4 +413,5 @@ const TruncatedParagraph = styled(Paragraph)`
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+    -webkit-box-align: start !important;
 `;

--- a/ts/utils/configs.ts
+++ b/ts/utils/configs.ts
@@ -12,6 +12,7 @@ const INFURA_API_KEY = environments.isDevelopment()
     : 'dbb71566cad444979f59c42b11b4f603';
 
 export const GHOST_API_KEY = process.env.GHOST_API_KEY || null;
+export const ZRX_FORUMS_API_KEY = process.env.ZRX_FORUMS_API_KEY;
 export const ALCHEMY_API_KEY = '8JwI7bMSK8ojsPDbyeHt6NK8w23afo1q';
 export const GOVERNOR_CONTRACT_ADDRESS = {
     COMPOUND: '0xc0dA01a04C3f3E0be433606045bB7017A7323E38',
@@ -22,6 +23,8 @@ export const GOVERNOR_CONTRACT_ADDRESS = {
 export const DEFAULT_POOL_ID = '51';
 
 export const GOVERNANCE_THEGRAPH_ENDPOINT = 'https://api.thegraph.com/subgraphs/name/mzhu25/zeroex-staking';
+
+export const FORUM_API_ENDPOINT = 'https://gov.0x.org';
 
 export const configs = {
     AMOUNT_DISPLAY_PRECSION: 5,

--- a/ts/utils/configs.ts
+++ b/ts/utils/configs.ts
@@ -12,7 +12,6 @@ const INFURA_API_KEY = environments.isDevelopment()
     : 'dbb71566cad444979f59c42b11b4f603';
 
 export const GHOST_API_KEY = process.env.GHOST_API_KEY || null;
-export const ZRX_FORUMS_API_KEY = process.env.ZRX_FORUMS_API_KEY;
 export const ALCHEMY_API_KEY = '8JwI7bMSK8ojsPDbyeHt6NK8w23afo1q';
 export const GOVERNOR_CONTRACT_ADDRESS = {
     COMPOUND: '0xc0dA01a04C3f3E0be433606045bB7017A7323E38',

--- a/ts/utils/fetch_utils.ts
+++ b/ts/utils/fetch_utils.ts
@@ -15,10 +15,15 @@ const logErrorIfPresent = (response: Response, requestedURL: string) => {
 };
 
 export const fetchUtils = {
-    async requestAsync<T = any>(baseUrl: string, path: string, queryParams?: object): Promise<T> {
+    async requestAsync<T = any>(
+        baseUrl: string,
+        path: string,
+        queryParams?: object,
+        options?: RequestInit,
+    ): Promise<T> {
         const query = queryStringFromQueryParams(queryParams);
         const url = `${baseUrl}${path}${query}`;
-        const response = await fetchAsync(url);
+        const response = await fetchAsync(url, options);
         logErrorIfPresent(response, url);
         const result = await response.json();
         return result;

--- a/ts/utils/forum_client.ts
+++ b/ts/utils/forum_client.ts
@@ -1,26 +1,27 @@
 import * as _ from 'lodash';
 import { fetchUtils } from 'ts/utils/fetch_utils';
-import { FORUM_API_ENDPOINT, ZRX_FORUMS_API_KEY } from './configs';
 
-type ForumUser = {
+import { FORUM_API_ENDPOINT } from './configs';
+
+interface ForumUser {
     id: number;
     username: string;
-};
+}
 
-type ForumTopic = {
+interface ForumTopic {
     id: number;
     title: string;
     author: ForumUser;
     numPosts: number;
     url: string;
-};
+}
 
-type ForumPosterResponse = {
+interface ForumPosterResponse {
     user_id: number;
     description: string;
-};
+}
 
-type ForumTopicResponse = {
+interface ForumTopicResponse {
     id: number;
     title: string;
     posters: ForumPosterResponse[];
@@ -28,14 +29,14 @@ type ForumTopicResponse = {
     visible: boolean;
     slug: string;
     category_id: number;
-};
+}
 
-type TopicApiResponse = {
+interface TopicApiResponse {
     users: ForumUser[];
     topic_list: {
         topics: ForumTopicResponse[];
     };
-};
+}
 
 const GOVERNANCE_SLUG = 'governance';
 const GOVERNANCE_CATEGORY_ID = 13;
@@ -44,7 +45,7 @@ function makeTopPostsPerCategoryEndpoint(slug: string, categoryId: number): stri
     return `/c/${slug}/${categoryId}/l/top.json?ascending=false`;
 }
 
-export async function getTopNPosts(numPosts: number = 3): Promise<ForumTopic[]> {
+export async function getTopNPostsAsync(numPosts: number = 3): Promise<ForumTopic[]> {
     const result = await fetchUtils.requestAsync<TopicApiResponse>(
         FORUM_API_ENDPOINT,
         makeTopPostsPerCategoryEndpoint(GOVERNANCE_SLUG, GOVERNANCE_CATEGORY_ID),

--- a/ts/utils/forum_client.ts
+++ b/ts/utils/forum_client.ts
@@ -1,14 +1,14 @@
 import * as _ from 'lodash';
 import { fetchUtils } from 'ts/utils/fetch_utils';
 
-import { FORUM_API_ENDPOINT } from './configs';
+import { FORUM_API_ENDPOINT, GOVERNANCE_THEGRAPH_ENDPOINT } from './configs';
 
 interface ForumUser {
     id: number;
     username: string;
 }
 
-interface ForumTopic {
+export interface ForumTopic {
     id: number;
     title: string;
     author: ForumUser;
@@ -45,16 +45,17 @@ function makeTopPostsPerCategoryEndpoint(slug: string, categoryId: number): stri
     return `/c/${slug}/${categoryId}/l/top.json?ascending=false`;
 }
 
-export async function getTopNPostsAsync(numPosts: number = 3): Promise<ForumTopic[]> {
-    const result = await fetchUtils.requestAsync<TopicApiResponse>(
-        FORUM_API_ENDPOINT,
-        makeTopPostsPerCategoryEndpoint(GOVERNANCE_SLUG, GOVERNANCE_CATEGORY_ID),
-        undefined,
-        {},
-    );
-    const topNRawResults = result.topic_list.topics.slice(0, numPosts);
-    const topNTopics: ForumTopic[] = topNRawResults.map((res) => {
-        const user: ForumUser = result.users.find(({ id }) => id === res.posters[0].user_id);
+function makeLatestPostsPerCategoryEndpoint(slug: string, categoryId: number, page: number = 0) {
+    return `/c/${slug}/${categoryId}/l/latest.json?ascending=false&page=${page}`;
+}
+
+function getOriginalPosterUser(apiRes: TopicApiResponse, topicRes: ForumTopicResponse): ForumUser {
+    return apiRes.users.find(({ id }) => id === topicRes.posters[0].user_id);
+}
+
+function buildTopicsFromApiResponse(apiRes: TopicApiResponse): ForumTopic[] {
+    return apiRes.topic_list.topics.map((res) => {
+        const user = getOriginalPosterUser(apiRes, res);
         return {
             id: res.id,
             title: res.title,
@@ -63,6 +64,44 @@ export async function getTopNPostsAsync(numPosts: number = 3): Promise<ForumTopi
             url: `${FORUM_API_ENDPOINT}/t/${res.slug}`,
         };
     });
+}
+
+export async function getTopNPostsAsync(numPosts: number = 3): Promise<ForumTopic[]> {
+    const result = await fetchUtils.requestAsync<TopicApiResponse>(
+        FORUM_API_ENDPOINT,
+        makeTopPostsPerCategoryEndpoint(GOVERNANCE_SLUG, GOVERNANCE_CATEGORY_ID),
+        undefined,
+        {},
+    );
+    const builtTopics = buildTopicsFromApiResponse(result);
+    const topNTopics = builtTopics.slice(0, numPosts);
 
     return topNTopics;
+}
+
+export async function getLatestNPostsFilteredAsync(
+    numPosts: number = 3,
+    filter: (topic: ForumTopic) => boolean,
+): Promise<ForumTopic[]> {
+    const out: ForumTopic[] = [];
+    let page = 0;
+    let result: TopicApiResponse = null;
+    while (out.length < numPosts) {
+        result = await fetchUtils.requestAsync<TopicApiResponse>(
+            FORUM_API_ENDPOINT,
+            makeLatestPostsPerCategoryEndpoint(GOVERNANCE_SLUG, GOVERNANCE_CATEGORY_ID, page++),
+        );
+        if (result.topic_list.topics.length === 0) {
+            break;
+        }
+        const buildTopics = buildTopicsFromApiResponse(result);
+        const filteredResults = buildTopics.filter(filter);
+        for (const res of filteredResults) {
+            out.push(res);
+            if (out.length === numPosts) {
+                break;
+            }
+        }
+    }
+    return out;
 }

--- a/ts/utils/forum_client.ts
+++ b/ts/utils/forum_client.ts
@@ -1,0 +1,67 @@
+import * as _ from 'lodash';
+import { fetchUtils } from 'ts/utils/fetch_utils';
+import { FORUM_API_ENDPOINT, ZRX_FORUMS_API_KEY } from './configs';
+
+type ForumUser = {
+    id: number;
+    username: string;
+};
+
+type ForumTopic = {
+    id: number;
+    title: string;
+    author: ForumUser;
+    numPosts: number;
+    url: string;
+};
+
+type ForumPosterResponse = {
+    user_id: number;
+    description: string;
+};
+
+type ForumTopicResponse = {
+    id: number;
+    title: string;
+    posters: ForumPosterResponse[];
+    posts_count: number;
+    visible: boolean;
+    slug: string;
+    category_id: number;
+};
+
+type TopicApiResponse = {
+    users: ForumUser[];
+    topic_list: {
+        topics: ForumTopicResponse[];
+    };
+};
+
+const GOVERNANCE_SLUG = 'governance';
+const GOVERNANCE_CATEGORY_ID = 13;
+
+function makeTopPostsPerCategoryEndpoint(slug: string, categoryId: number): string {
+    return `/c/${slug}/${categoryId}/l/top.json?ascending=false`;
+}
+
+export async function getTopNPosts(numPosts: number = 3): Promise<ForumTopic[]> {
+    const result = await fetchUtils.requestAsync<TopicApiResponse>(
+        FORUM_API_ENDPOINT,
+        makeTopPostsPerCategoryEndpoint(GOVERNANCE_SLUG, GOVERNANCE_CATEGORY_ID),
+        undefined,
+        {},
+    );
+    const topNRawResults = result.topic_list.topics.slice(0, numPosts);
+    const topNTopics: ForumTopic[] = topNRawResults.map((res) => {
+        const user: ForumUser = result.users.find(({ id }) => id === res.posters[0].user_id);
+        return {
+            id: res.id,
+            title: res.title,
+            author: user,
+            numPosts: res.posts_count,
+            url: `${FORUM_API_ENDPOINT}/t/${res.slug}`,
+        };
+    });
+
+    return topNTopics;
+}

--- a/ts/utils/forum_client.ts
+++ b/ts/utils/forum_client.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { fetchUtils } from 'ts/utils/fetch_utils';
 
-import { FORUM_API_ENDPOINT, GOVERNANCE_THEGRAPH_ENDPOINT } from './configs';
+import { FORUM_API_ENDPOINT } from './configs';
 
 interface ForumUser {
     id: number;
@@ -45,7 +45,7 @@ function makeTopPostsPerCategoryEndpoint(slug: string, categoryId: number): stri
     return `/c/${slug}/${categoryId}/l/top.json?ascending=false`;
 }
 
-function makeLatestPostsPerCategoryEndpoint(slug: string, categoryId: number, page: number = 0) {
+function makeLatestPostsPerCategoryEndpoint(slug: string, categoryId: number, page: number = 0): string {
     return `/c/${slug}/${categoryId}/l/latest.json?ascending=false&page=${page}`;
 }
 


### PR DESCRIPTION
This PR adds cards to the governance page that display the current top three topics in the governance category. 
<img width="1206" alt="Screenshot 2022-03-16 at 17 39 12" src="https://user-images.githubusercontent.com/24787761/158845989-44f30704-4d84-4f59-80eb-7f65439d3a31.png">

Additionally the description in the vote cards has been clamped to three lines
<img width="1193" alt="Screenshot 2022-03-16 at 17 56 46" src="https://user-images.githubusercontent.com/24787761/158846147-a7eb9489-6bd6-4ab3-a43a-9e5118dbf8b6.png">
<img width="535" alt="Screenshot 2022-03-16 at 17 57 20" src="https://user-images.githubusercontent.com/24787761/158846163-b06cb50c-53f8-404d-af95-edbdd1e24009.png">

