### PR TITLE
Always connect to rpc node initially

### DIFF
--- a/ts/utils/configs.ts
+++ b/ts/utils/configs.ts
@@ -70,7 +70,11 @@ export const configs = {
     ] as OutdatedWrappedEtherByNetworkId[],
     // The order matters. We first try first node and only then fall back to others.
     PUBLIC_NODE_URLS_BY_NETWORK_ID: {
-        [1]: ['https://eth-mainnet.alchemyapi.io/v2/8JwI7bMSK8ojsPDbyeHt6NK8w23afo1q'], // [`https://mainnet.infura.io/v3/${INFURA_API_KEY}`, 'https://mainnet.0x.org'],
+        [1]: [
+            environments.isDevelopment()
+                ? 'https://mainnet.0x.org'
+                : 'https://eth-mainnet.alchemyapi.io/v2/8JwI7bMSK8ojsPDbyeHt6NK8w23afo1q',
+        ], // [`https://mainnet.infura.io/v3/${INFURA_API_KEY}`, 'https://mainnet.0x.org'],
         [42]: [`https://kovan.infura.io/v3/${INFURA_API_KEY}`, 'https://kovan.0x.org'],
         [3]: [`https://ropsten.infura.io/v3/${INFURA_API_KEY}`],
         [4]: [`https://rinkeby.infura.io/v3/${INFURA_API_KEY}`],

--- a/ts/utils/providers/provider_state_factory.ts
+++ b/ts/utils/providers/provider_state_factory.ts
@@ -20,14 +20,18 @@ export const providerStateFactory = {
             const provider = providerUtils.standardizeOrThrow(supportedProvider);
             return providerStateFactory.getInitialProviderStateFromProvider(provider, walletDisplayName);
         }
-        const providerStateFromWindowIfExits = providerStateFactory.getInitialProviderStateFromWindowIfExists(
-            walletDisplayName,
-        );
-        if (providerStateFromWindowIfExits) {
-            return providerStateFromWindowIfExits;
-        } else {
-            return providerStateFactory.getInitialProviderStateFallback(fallbackNetworkId, walletDisplayName);
-        }
+        return providerStateFactory.getInitialProviderStateFallback(fallbackNetworkId, walletDisplayName);
+        // We don't currently initially connect to a wallet, we only use public RDC nodes.
+        // Connection to a wallet (so far) is a manual process
+        //
+        // const providerStateFromWindowIfExits = providerStateFactory.getInitialProviderStateFromWindowIfExists(
+        //     walletDisplayName,
+        // );
+        // if (providerStateFromWindowIfExits) {
+        //     return providerStateFromWindowIfExits;
+        // } else {
+        //     return providerStateFactory.getInitialProviderStateFallback(fallbackNetworkId, walletDisplayName);
+        // }
     },
 
     getInitialProviderStateFromProvider: (provider: ZeroExProvider, walletDisplayName?: string): ProviderState => {


### PR DESCRIPTION
This PR allows treasury information to be displayed without a connected wallet 