### PR TITLE
Removes gray background on featured liquidity sources container

### DIFF
--- a/ts/components/sections/landing/about.tsx
+++ b/ts/components/sections/landing/about.tsx
@@ -42,7 +42,7 @@ export const SectionLandingAbout = () => {
                     </Paragraph>
                 </div>
 
-                <WrapGrid bgColor={'#8F8F8F'} isWrapped={true}>
+                <WrapGrid isWrapped={true}>
                     {_.map(projects, (item: ProjectLogo, index) => (
                         <StyledProject key={`client-${index}`} isOnMobile={item.persistOnMobile}>
                             <img src={item.imageUrl} alt={item.name} />


### PR DESCRIPTION
If this was intentional, just lmk. Just looked a bit out of place when I was browsing the home page.

Before:
![Screen Shot 2022-04-22 at 1 49 04 AM](https://user-images.githubusercontent.com/1103963/164611618-67845805-eb4e-4547-b04b-99d98a8b6844.png)

After:
![Screen Shot 2022-04-22 at 1 48 56 AM](https://user-images.githubusercontent.com/1103963/164611624-b2da4dc7-0f54-49b5-96e0-0c51c2d922c4.png)

