### PR TITLE
Fix/undefined treasury summary paragraph

### DIFF
--- a/ts/components/governance/treasury_summary.tsx
+++ b/ts/components/governance/treasury_summary.tsx
@@ -12,9 +12,12 @@ export const TreasurySummary: React.FC<{ description: string }> = ({ description
     const paragraph = tokens.find((token: Token) => (token as Tokens.Paragraph).type === 'paragraph');
     let summary = '';
     // @ts-ignore
-    if (paragraph?.tokens) paragraph.tokens.forEach((token) => {
-        summary += token.text;
-    });
+    if (paragraph?.tokens) {
+        // @ts-ignore
+        paragraph.tokens.forEach((token) => {
+            summary += token.text;
+        });
+    }
 
     return (
         <>

--- a/ts/components/governance/treasury_summary.tsx
+++ b/ts/components/governance/treasury_summary.tsx
@@ -12,7 +12,7 @@ export const TreasurySummary: React.FC<{ description: string }> = ({ description
     const paragraph = tokens.find((token: Token) => (token as Tokens.Paragraph).type === 'paragraph');
     let summary = '';
     // @ts-ignore
-    paragraph.tokens.forEach((token) => {
+    if (paragraph?.tokens) paragraph.tokens.forEach((token) => {
         summary += token.text;
     });
 


### PR DESCRIPTION
The governance website is throwing a runtime error because `paragraph.tokens` is undefined in `treasury_summary.tsx`. This fix adds a null check around that property to fix that & successfully render the component.

[More details in this slack thread.](https://0xproject.slack.com/archives/CBD1R58P5/p1679692887701629)