### PR TITLE
fix: bump github actions to node24 runtimes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,21 +8,21 @@ jobs:
         env:
             CI: true
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
             - name: Setup node 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 9.15.0
             - name: Get pnpm store directory
               shell: bash
               run: |
                   echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               name: Setup pnpm cache
               with:
                   path: ${{ env.STORE_PATH }}
@@ -30,7 +30,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-pnpm-store-
             - run: pnpm install --frozen-lockfile
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: cache-deps
               with:
                   path: '.'
@@ -39,17 +39,17 @@ jobs:
         runs-on: ubuntu-latest
         needs: install-dependencies
         steps:
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: restore-deps
               with:
                   path: '.'
                   key: ${{ github.sha }}-deps
             - name: Setup node 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 9.15.0
             - run: pnpm lint
@@ -57,17 +57,17 @@ jobs:
         runs-on: ubuntu-latest
         needs: install-dependencies
         steps:
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: restore-deps
               with:
                   path: '.'
                   key: ${{ github.sha }}-deps
             - name: Setup node 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 9.15.0
             - run: pnpm test
@@ -78,21 +78,21 @@ jobs:
             matrix:
                 node-version: [24.x]
         steps:
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: restore-deps
               with:
                   path: '.'
                   key: ${{ github.sha }}
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 9.15.0
             - run: pnpm build:prod
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: cache-build
               with:
                   path: '.'


### PR DESCRIPTION
GitHub removes Node ≤20 action runtimes from runners on 2026-09-16 (forced Node 24 default since 2026-06-16) — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions updated to their Node 24 releases:

- `actions/cache` v4 → v5
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v4 → v6